### PR TITLE
Fix Issue#10 : Handle TNT and Projectiles in Kill Mob Objective

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,13 @@
     <dependencies>
         <dependency>
             <groupId>org.bukkit</groupId>
+            <artifactId>craftbukkit</artifactId>
+            <version>1.8-R0.1-SNAPSHOT</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/lib/craftbukkit-1.8.jar</systemPath>
+        </dependency>
+        <dependency>
+            <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
             <version>1.8-R0.1-SNAPSHOT</version>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,7 @@
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
             <version>1.8-R0.1-SNAPSHOT</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/lib/craftbukkit-1.8.jar</systemPath>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.bukkit</groupId>

--- a/src/main/java/me/blackvein/quests/PlayerListener.java
+++ b/src/main/java/me/blackvein/quests/PlayerListener.java
@@ -603,6 +603,36 @@ public class PlayerListener implements Listener, ColorUtil {
                             }
                         }
 
+                    } else if (damager instanceof TNTPrimed) {
+                        TNTPrimed tnt = (TNTPrimed)damager;
+                        Entity source = tnt.getSource();
+
+                        if(source instanceof Player) {
+
+                            Player player = (Player) source;
+                            boolean okay = true;
+
+                            if (plugin.citizens != null) {
+                                if (CitizensAPI.getNPCRegistry().isNPC(player)) {
+                                    okay = false;
+                                }
+                            }
+
+                            if (okay) {
+
+                                Quester quester = plugin.getQuester(player.getUniqueId());
+
+                                for (Quest quest : quester.currentQuests.keySet()) {
+
+                                    if (quester.hasObjective(quest, "killMob")) {
+                                        quester.killMob(quest, evt.getEntity().getLocation(), evt.getEntity().getType());
+                                    }
+
+                                }
+
+                            }
+                        }
+
                     } else if (damager instanceof Player) {
 
                         boolean okay = true;

--- a/src/main/java/me/blackvein/quests/PlayerListener.java
+++ b/src/main/java/me/blackvein/quests/PlayerListener.java
@@ -33,6 +33,7 @@ import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.*;
 import org.bukkit.event.player.PlayerFishEvent.State;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.projectiles.ProjectileSource;
 
 public class PlayerListener implements Listener, ColorUtil {
 
@@ -566,19 +567,19 @@ public class PlayerListener implements Listener, ColorUtil {
     public void onEntityDeath(EntityDeathEvent evt) {
 
         if (evt.getEntity() instanceof Player == false) {
-
             if (evt.getEntity().getLastDamageCause() instanceof EntityDamageByEntityEvent) {
 
                 EntityDamageByEntityEvent damageEvent = (EntityDamageByEntityEvent) evt.getEntity().getLastDamageCause();
                 Entity damager = damageEvent.getDamager();
-
                 if (damager != null) {
 
                     if (damager instanceof Projectile) {
+                        Projectile projectile = (Projectile)damager;
+                        ProjectileSource source = projectile.getShooter();
 
-                        if(evt.getEntity().getLastDamageCause().getEntity() instanceof Player) {
+                        if(source instanceof Player) {
 
-                        	Player player = (Player) evt.getEntity().getLastDamageCause().getEntity();
+                        	Player player = (Player) source;
                             boolean okay = true;
 
                             if (plugin.citizens != null) {

--- a/src/main/java/me/blackvein/quests/Quests.java
+++ b/src/main/java/me/blackvein/quests/Quests.java
@@ -4766,7 +4766,9 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
         		UUID.fromString(s);
         		return true;
         	} catch (IllegalArgumentException e) {
-        		e.printStackTrace();
+                // Maybe only enable this when debugging?
+                // When it fails, it can generate gigabyte-sized log files.
+        		// e.printStackTrace();
         	}
         	
         }


### PR DESCRIPTION
This address issue #10 with regards to projectiles and TNT.

This does not seem to address the cases of punching a mob off of a cliff, into fire/lava, or any of those secondary kills. I'm not sure how to do that.

Tested with splash potions, projectiles, direct damage (via another plugin) and placing and lighting a TNT block.

This also comments out the stacktrace in checkQuester, it gave me a 15GB log file. I'm not sure what's going wrong there, but I opened issue #14 for this.