### PR TITLE
Feature/cmd/admin/remove completed quest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /target
+
+# Ignore IDEA files
+/.idea
+*.iml

--- a/src/main/java/me/blackvein/quests/Quester.java
+++ b/src/main/java/me/blackvein/quests/Quester.java
@@ -39,10 +39,10 @@ public class Quester {
     UUID id;
     boolean editorMode = false;
     boolean hasJournal = false;
-    
+
     public String questToTake;
     public Map<Quest, Integer> currentQuests = new ConcurrentHashMap<Quest, Integer>() {
-        
+
 		private static final long serialVersionUID = 6361484975823846780L;
 
 		@Override
@@ -58,7 +58,7 @@ public class Quester {
             updateJournal();
             return i;
         }
-        
+
         @Override
         public void clear() {
             super.clear();
@@ -70,9 +70,9 @@ public class Quester {
             super.putAll(m);
             updateJournal();
         }
-        
+
     };
-    
+
     int questPoints = 0;
     Quests plugin;
     public LinkedList<String> completedQuests = new LinkedList<String>() {
@@ -132,20 +132,20 @@ public class Quester {
             updateJournal();
             return s;
         }
-        
+
     };
-    
+
     Map<String, Long> completedTimes = new HashMap<String, Long>();
-    
+
     Map<String, Integer> amountsCompleted = new HashMap<String, Integer>() {
-        
+
 		private static final long serialVersionUID = 5475202358792520975L;
 
 		/*@SuppressWarnings("unused")
 		public void hardClear() {
             super.clear();
         }*/
-        
+
         @Override
         public Integer put(String key, Integer val) {
             Integer data = super.put(key, val);
@@ -159,7 +159,7 @@ public class Quester {
             updateJournal();
             return i;
         }
-        
+
         @Override
         public void clear() {
             super.clear();
@@ -171,12 +171,12 @@ public class Quester {
             super.putAll(m);
             updateJournal();
         }
-        
+
     };
 
-    
+
     Map<Quest, QuestData> questData = new HashMap<Quest, QuestData>() {
-        
+
 		private static final long serialVersionUID = -4607112433003926066L;
 
 		@Override
@@ -185,7 +185,7 @@ public class Quester {
             updateJournal();
             return data;
         }
-        
+
         @Override
         public QuestData remove(Object key) {
             QuestData data = super.remove(key);
@@ -204,7 +204,7 @@ public class Quester {
             super.putAll(m);
             updateJournal();
         }
-        
+
     };
 
     final Random random = new Random();
@@ -214,7 +214,7 @@ public class Quester {
         plugin = newPlugin;
 
     }
-    
+
     public Player getPlayer() {
 
         return Bukkit.getServer().getPlayer(id);
@@ -228,66 +228,66 @@ public class Quester {
     }
 
     public void updateJournal() {
-        
+
         if(!hasJournal)
             return;
-        
+
         Inventory inv = getPlayer().getInventory();
         ItemStack[] arr = inv.getContents();
         int index = -1;
-        
+
         for(int i = 0; i < arr.length; i++) {
-            
+
             if(arr[i] != null) {
-                
+
                 if(ItemUtil.isJournal(arr[i])) {
                     index = i;
                     break;
                 }
-                
+
             }
-            
+
         }
-        
+
         if(index != -1) {
-            
+
             ItemStack stack = new ItemStack(Material.WRITTEN_BOOK, 1);
             ItemMeta meta = stack.getItemMeta();
             meta.setDisplayName(ChatColor.LIGHT_PURPLE + Lang.get("journalTitle"));
-            
+
             BookMeta book = (BookMeta) meta;
             book.setTitle(ChatColor.LIGHT_PURPLE + Lang.get("journalTitle"));
             book.setAuthor(getPlayer().getName());
 
             if(currentQuests.isEmpty()) {
-            	
+
             	book.addPage(ChatColor.DARK_RED + Lang.get("journalNoQuests"));
-            	
+
             } else {
-                
+
                 int currentLength = 0;
                 int currentLines = 0;
                 String page = "";
-                
+
                 for(Quest quest : currentQuests.keySet()) {
-                    
+
                     if((currentLength + quest.name.length() > 240) || (currentLines + ((quest.name.length() % 19) == 0 ? (quest.name.length() / 19) : ((quest.name.length() / 19) + 1))) > 13) {
-                        
+
                         book.addPage(page);
                         page += ChatColor.DARK_PURPLE + "" + ChatColor.BOLD + quest.name + "\n";
                         currentLength = quest.name.length();
                         currentLines = (quest.name.length() % 19) == 0 ? (quest.name.length() / 19) : (quest.name.length() + 1);
-                        
+
                     } else {
-                        
+
                         page += ChatColor.DARK_PURPLE + "" + ChatColor.BOLD + quest.name + "\n";
                         currentLength += quest.name.length();
                         currentLines += (quest.name.length() / 19);
-                        
+
                     }
 
                     for(String obj : getObjectivesReal(quest)) {
-                        
+
                         //Length/Line check
                         if((currentLength + obj.length() > 240) || (currentLines + ((obj.length() % 19) == 0 ? (obj.length() / 19) : ((obj.length() / 19) + 1))) > 13) {
                             book.addPage(page);
@@ -299,28 +299,28 @@ public class Quester {
                             currentLength += obj.length();
                             currentLines += (obj.length() / 19);
                         }
-                        
+
                     }
-                    
+
                     if(currentLines < 13)
                         page += "\n";
-                    
+
                     book.addPage(page);
                     page = "";
                     currentLines = 0;
                     currentLength = 0;
-                
+
                 }
-                
+
             }
 
             stack.setItemMeta(book);
             inv.setItem(index, stack);
-            
+
         }
-        
+
     }
-    
+
     public Stage getCurrentStage(Quest quest) {
     	if (currentQuests.containsKey(quest)) {
     		return quest.getStage(currentQuests.get(quest));
@@ -421,7 +421,7 @@ public class Quester {
 
         if(getQuestData(quest) == null)
             return new LinkedList<String>();
-        
+
         LinkedList<String> unfinishedObjectives = new LinkedList<String>();
         LinkedList<String> finishedObjectives = new LinkedList<String>();
         LinkedList<String> objectives = new LinkedList<String>();
@@ -666,7 +666,7 @@ public class Quester {
         }
 
         for (ItemStack is : getCurrentStage(quest).itemsToDeliver) {
-            
+
             int delivered = getQuestData(quest).itemsDelivered.get(is);
             int amt = is.getAmount();
             Integer npc = getCurrentStage(quest).itemDeliveryTargets.get(getCurrentStage(quest).itemsToDeliver.indexOf(is));
@@ -792,7 +792,7 @@ public class Quester {
 
                 if (l.equals(l2)) {
                 	if (!getQuestData(quest).hasReached.isEmpty()) {
-                		
+
                 		if (getQuestData(quest).hasReached.get(getQuestData(quest).locationsReached.indexOf(l2)) == false) {
 
                 			String obj = Lang.get("goTo");
@@ -806,7 +806,7 @@ public class Quester {
                         	finishedObjectives.add(ChatColor.GRAY + obj);
 
                 		}
-                    
+
                 	}
 
                 }
@@ -1707,12 +1707,12 @@ public class Quester {
                 data.customObjectiveCounts.put(co.getName(), 0);
             }
         }
-        
+
         data.setDoJournalUpdate(true);
         hardDataPut(quest, data);
 
     }
-    
+
     public void addEmptiesFor(Quest quest, int stage) {
 
         QuestData data = new QuestData(this);
@@ -1856,7 +1856,7 @@ public class Quester {
                 data.customObjectiveCounts.put(co.getName(), 0);
             }
         }
-        
+
         data.setDoJournalUpdate(true);
         hardDataPut(quest, data);
 
@@ -1982,7 +1982,7 @@ public class Quester {
     public static String capitalsToSpaces(String s) {
 
         int max = s.length();
-        
+
         for (int i = 1; i < max; i++) {
 
             if (Character.isUpperCase(s.charAt(i))) {
@@ -1990,7 +1990,7 @@ public class Quester {
                 s = s.substring(0, i) + " " + s.substring(i);
                 i++;
                 max++;
-                
+
             }
 
         }
@@ -2087,7 +2087,7 @@ public class Quester {
             for (Quest quest : currentQuests.keySet()) {
 
                 ConfigurationSection questSec = dataSec.createSection(quest.name);
-                
+
                 if (getQuestData(quest).blocksDamaged.isEmpty() == false) {
 
                     LinkedList<String> blockNames = new LinkedList<String>();
@@ -2505,7 +2505,7 @@ public class Quester {
         } catch (InvalidConfigurationException e) {
             return false;
         }
-        
+
         hardClear();
 
         if (data.contains("completedRedoableQuests")) {
@@ -2543,7 +2543,7 @@ public class Quester {
         }
 
         questPoints = data.getInt("quest-points");
-        
+
         hasJournal = data.getBoolean("hasJournal");
 
         if (data.isList("completed-Quests")) {
@@ -2574,15 +2574,15 @@ public class Quester {
             	if (plugin.getQuest(questNames.get(i)) != null) {
             		currentQuests.put(plugin.getQuest(questNames.get(i)), questStages.get(i));
             	}
-                
+
             }
 
             ConfigurationSection dataSec = data.getConfigurationSection("questData");
-            
+
             if (dataSec.getKeys(false).isEmpty()) {
             	return false;
             }
-            
+
             for (String key : dataSec.getKeys(false)) {
 
                 ConfigurationSection questSec = dataSec.getConfigurationSection(key);
@@ -2775,10 +2775,10 @@ public class Quester {
                     for (int i = 0; i < deliveryAmounts.size(); i++) {
 
                     	if (i < getCurrentStage(quest).itemsToDeliver.size()) {
-                    		
+
                             getQuestData(quest).itemsDelivered.put(getCurrentStage(quest).itemsToDeliver.get(i), deliveryAmounts.get(i));
 
-                    		
+
                     	}
 
                     }
@@ -2944,13 +2944,13 @@ public class Quester {
             }
 
         }
-        
+
         return true;
 
     }
 
 public static ConfigurationSection getLegacyQuestData(FileConfiguration questSec, String questName) {
-        
+
     ConfigurationSection newData = questSec.createSection("questData");
 
     if (questSec.contains("blocks-damaged-names")) {
@@ -3036,7 +3036,7 @@ public static ConfigurationSection getLegacyQuestData(FileConfiguration questSec
 
         newData.set(questName + ".mobs-killed", mobs);
         newData.set(questName + ".mobs-killed-amounts", amounts);
-        
+
         if (questSec.contains("mob-kill-locations")) {
 
             List<String> locations = questSec.getStringList("mob-kill-locations");
@@ -3044,7 +3044,7 @@ public static ConfigurationSection getLegacyQuestData(FileConfiguration questSec
 
             newData.set(questName + ".mob-kill-locations", locations);
             newData.set(questName + ".mob-kill-location-radii", radii);
-            
+
         }
 
     }
@@ -3123,7 +3123,7 @@ public static ConfigurationSection getLegacyQuestData(FileConfiguration questSec
 
         List<String> passwords = questSec.getStringList("passwords");
         List<Boolean> said = questSec.getBooleanList("passwords-said");
-        
+
         newData.set(questName + ".passwords", passwords);
         newData.set(questName + ".passwords-said", said);
 
@@ -3151,7 +3151,7 @@ public static ConfigurationSection getLegacyQuestData(FileConfiguration questSec
         newData.set(questName + ".chat-triggers", triggers);
 
     }
-    
+
     return newData;
 
 }
@@ -3371,21 +3371,21 @@ if (quest != null) {
         for (int i = 0; i < quests.size(); i++) {
 
             if (quests.get(i).guiDisplay != null) {
-                
+
                 ItemStack display = quests.get(i).guiDisplay;
                 ItemMeta meta = display.getItemMeta();
                 meta.setDisplayName(ChatColor.DARK_PURPLE + Quests.parseString(quests.get(i).getName(), npc));
-                
+
                 if (!meta.hasLore()) {
                 	LinkedList<String> lines = new LinkedList<String>();
-                
+
                 	lines = MiscUtil.makeLines(quests.get(i).description, " ", 40, ChatColor.DARK_GREEN);
-                
+
                 	meta.setLore(lines);
                 }
-                
+
                 display.setItemMeta(meta);
-                
+
                 inv.setItem(inc, display);
                 inc++;
             }
@@ -3395,20 +3395,20 @@ if (quest != null) {
         player.openInventory(inv);
 
     }
-    
+
     public void hardQuit(Quest quest) {
-        
+
         try {
             currentQuests.remove(quest);
             questData.remove(quest);
         } catch (Exception ex) {
             Logger.getLogger(Quests.class.getName()).log(Level.SEVERE, null, ex);
         }
-        
+
     }
-    
+
     public void hardClear() {
-        
+
         try {
             currentQuests.clear();
             questData.clear();
@@ -3416,27 +3416,38 @@ if (quest != null) {
         } catch (Exception ex) {
             Logger.getLogger(Quests.class.getName()).log(Level.SEVERE, null, ex);
         }
-        
+
     }
-    
+
     public void hardStagePut(Quest key, Integer val) {
-        
+
         try {
             currentQuests.put(key, val);
         } catch (Exception ex) {
             Logger.getLogger(Quests.class.getName()).log(Level.SEVERE, null, ex);
         }
-        
+
     }
-    
+
     public void hardDataPut(Quest key, QuestData val) {
-        
+
         try {
             questData.put(key, val);
         } catch (Exception ex) {
             Logger.getLogger(Quests.class.getName()).log(Level.SEVERE, null, ex);
         }
-        
+
+    }
+
+    /**
+     *
+     * @param quest quest to be removed
+     * @return {@code true} if completedQuests contained the specified quest
+     */
+    public boolean removeCompletedQuests(Quest quest) {
+        boolean containedQuest = this.completedQuests.remove(quest.name);
+        this.saveData();
+        return containedQuest;
     }
 
 }

--- a/src/main/java/me/blackvein/quests/Quests.java
+++ b/src/main/java/me/blackvein/quests/Quests.java
@@ -22,6 +22,7 @@ import me.blackvein.quests.util.ColorUtil;
 import me.blackvein.quests.util.ItemUtil;
 import me.blackvein.quests.util.Lang;
 import me.blackvein.quests.util.MiscUtil;
+import me.blackvein.quests.util.PlayerFinder;
 import net.aufdemrand.denizen.Denizen;
 import net.aufdemrand.denizencore.scripts.ScriptRegistry;
 import net.citizensnpcs.api.CitizensAPI;

--- a/src/main/java/me/blackvein/quests/Quests.java
+++ b/src/main/java/me/blackvein/quests/Quests.java
@@ -327,6 +327,7 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
         commands.put(Lang.get("COMMAND_INFO"), 1); // info 
         commands.put(Lang.get("COMMAND_JOURNAL"), 1); // journal 
         
+        adminCommands.put(Lang.get("COMMAND_QUESTADMIN_STATS"), 2); // stats [player]
         adminCommands.put(Lang.get("COMMAND_QUESTADMIN_GIVE"), 3); // give [player] [quest]
         adminCommands.put(Lang.get("COMMAND_QUESTADMIN_QUIT"), 3); // quit [player] [quest]
         adminCommands.put(Lang.get("COMMAND_QUESTADMIN_POINTS"), 3); // points [player] [amount]
@@ -830,6 +831,10 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
         } else if (args[0].equalsIgnoreCase(Lang.get("COMMAND_QUESTADMIN_PURGE"))) {
 
             adminPurge(cs, args);
+
+        } else if (args[0].equalsIgnoreCase(Lang.get("COMMAND_QUESTADMIN_STATS"))) {
+
+            adminStats(cs, args);
         
         } else {
 
@@ -1555,6 +1560,24 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
         }
     }
 
+    private void adminStats(final CommandSender cs, String[] args) {
+        // Reject usage without permission
+        if (!cs.hasPermission("quests.admin.*") && !cs.hasPermission("quests.admin.stats")) {
+            cs.sendMessage(RED + Lang.get("questCmdNoPerms"));
+            return;
+        }
+
+        Player target_online_player = PlayerFinder.findOnlinePlayerByPartialCaseInsensitiveNameMatch(args[1]);
+
+        // Reject usage without matching online player
+        if (target_online_player == null) {
+            cs.sendMessage(YELLOW + Lang.get("playerNotFound"));
+            return;
+        }
+
+        questsStats(target_online_player, cs);
+    }
+
     private boolean questActionsCommandHandler(final CommandSender cs, String[] args) {
 
         if (cs instanceof Player) {
@@ -1745,16 +1768,25 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
     }
 
     private void questsStats(final Player player) {
+        questsStats(player, null);
+    }
+
+    private void questsStats(final Player player, final CommandSender customMessageTarget) {
+
+        CommandSender messageTarget = player;
+        if (customMessageTarget != null) {
+            messageTarget = customMessageTarget;
+        }
 
         Quester quester = getQuester(player.getUniqueId());
-        player.sendMessage(GOLD + "- " + player.getName() + " -");
-        player.sendMessage(YELLOW + Lang.get("questPointsDisplay") + " " + PURPLE + quester.questPoints + "/" + totalQuestPoints);
+        messageTarget.sendMessage(GOLD + "- " + player.getName() + " -");
+        messageTarget.sendMessage(YELLOW + Lang.get("questPointsDisplay") + " " + PURPLE + quester.questPoints + "/" + totalQuestPoints);
         if (quester.currentQuests.isEmpty()) {
-            player.sendMessage(YELLOW + Lang.get("currentQuest") + " " + PURPLE + Lang.get("none"));
+            messageTarget.sendMessage(YELLOW + Lang.get("currentQuest") + " " + PURPLE + Lang.get("none"));
         } else {
-            player.sendMessage(YELLOW + Lang.get("currentQuest"));
+            messageTarget.sendMessage(YELLOW + Lang.get("currentQuest"));
             for (Quest q : quester.currentQuests.keySet()) {
-                player.sendMessage(PINK + " - " + PURPLE + q.name);
+                messageTarget.sendMessage(PINK + " - " + PURPLE + q.name);
             }
         }
 
@@ -1781,8 +1813,8 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
 
         }
 
-        player.sendMessage(YELLOW + Lang.get("completedQuestsTitle"));
-        player.sendMessage(completed);
+        messageTarget.sendMessage(YELLOW + Lang.get("completedQuestsTitle"));
+        messageTarget.sendMessage(completed);
     }
     
     private void questsJournal(final Player player) {
@@ -2378,6 +2410,7 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
         cs.sendMessage("");
         cs.sendMessage(DARKRED + "/questadmin" + RED + " " + Lang.get("COMMAND_QUESTADMIN_HELP"));
         if(cs.hasPermission("quests.admin.*")){
+        	cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_STATS_HELP"));
         	cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_GIVE_HELP"));
             cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_QUIT_HELP"));
             cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_POINTS_HELP"));
@@ -2391,6 +2424,9 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
             cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_TOGGLEGUI_HELP"));
             cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_RELOAD_HELP"));
         } else{
+        	if (cs.hasPermission("quests.admin.stats")) {
+        		cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_STATS_HELP"));
+        	}
         	if (cs.hasPermission("quests.admin.give")) {
         		cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_GIVE_HELP"));
         	}

--- a/src/main/java/me/blackvein/quests/Quests.java
+++ b/src/main/java/me/blackvein/quests/Quests.java
@@ -92,7 +92,7 @@ import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.inventory.meta.ItemMeta;
 
 public class Quests extends JavaPlugin implements ConversationAbandonedListener, ColorUtil {
-	
+
     public static Economy economy = null;
     public static Permission permission = null;
     public static WorldGuardPlugin worldGuard = null;
@@ -193,7 +193,7 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
         defaultQuestsFile();
         defaultEventsFile();
         defaultDataFile();
-        
+
         loadCommands();
 
         getServer().getPluginManager().registerEvents(pListener, this);
@@ -225,14 +225,14 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
                 getLogger().log(Level.INFO, "" + events.size() + " Event(s) loaded.");
                 getLogger().log(Level.INFO, "" + Lang.getPhrases() + " Phrase(s) loaded.");
                 questers.putAll(getOnlineQuesters());
-                
+
                 if(convertData) {
-                    
+
                     convertQuesters();
-                    
+
                     FileConfiguration config = getConfig();
                     config.set("convert-data-on-startup", false);
-                    
+
                     try {
                         config.save(new File(Quests.this.getDataFolder(), "config.yml"));
                     } catch (IOException e) {
@@ -313,20 +313,20 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
     }
 
     public void loadCommands() {
-        
+
         // [] - required
         // {} - optional
-        
+
         commands.put(Lang.get("COMMAND_LIST"), 1); // list {page}
         commands.put(Lang.get("COMMAND_TAKE"), 2); // take [quest]
         commands.put(Lang.get("COMMAND_QUIT"), 2); // quit [quest]
         commands.put(Lang.get("COMMAND_EDITOR"), 1); // editor
-        commands.put(Lang.get("COMMAND_EVENTS_EDITOR"), 1); // events 
+        commands.put(Lang.get("COMMAND_EVENTS_EDITOR"), 1); // events
         commands.put(Lang.get("COMMAND_STATS"), 1); // stats
-        commands.put(Lang.get("COMMAND_TOP"), 2); // top [number] 
-        commands.put(Lang.get("COMMAND_INFO"), 1); // info 
-        commands.put(Lang.get("COMMAND_JOURNAL"), 1); // journal 
-        
+        commands.put(Lang.get("COMMAND_TOP"), 2); // top [number]
+        commands.put(Lang.get("COMMAND_INFO"), 1); // info
+        commands.put(Lang.get("COMMAND_JOURNAL"), 1); // journal
+
         adminCommands.put(Lang.get("COMMAND_QUESTADMIN_STATS"), 2); // stats [player]
         adminCommands.put(Lang.get("COMMAND_QUESTADMIN_GIVE"), 3); // give [player] [quest]
         adminCommands.put(Lang.get("COMMAND_QUESTADMIN_QUIT"), 3); // quit [player] [quest]
@@ -338,19 +338,20 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
         adminCommands.put(Lang.get("COMMAND_QUESTADMIN_NEXTSTAGE"), 3); // nextstage [player] [quest]
         adminCommands.put(Lang.get("COMMAND_QUESTADMIN_SETSTAGE"), 4); // setstage [player] [quest] [stage]
         adminCommands.put(Lang.get("COMMAND_QUESTADMIN_PURGE"), 2); // purge [player]
+        adminCommands.put(Lang.get("COMMAND_QUESTADMIN_REMOVECOMPLETEDQUEST"), 3); // removecompletedquest [player] [quest]
         adminCommands.put(Lang.get("COMMAND_QUESTADMIN_TOGGLEGUI"), 2); // togglegui [npc id]
         adminCommands.put(Lang.get("COMMAND_QUESTADMIN_RELOAD"), 1); // reload
-        
+
     }
-    
+
     public String checkCommand(String cmd, String[] args) {
-        
+
         if(cmd.equalsIgnoreCase("quest") || args.length == 0) {
             return null;
         }
-        
+
         if(cmd.equalsIgnoreCase("quests")) {
-        
+
             if(commands.containsKey(args[0].toLowerCase())) {
 
                 int min = commands.get(args[0].toLowerCase());
@@ -360,11 +361,11 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
                     return null;
 
             }
-            
+
             return YELLOW + Lang.get("questsUnknownCommand");
-            
+
         } else if(cmd.equalsIgnoreCase("questsadmin") || cmd.equalsIgnoreCase("questadmin")) {
-            
+
             if(adminCommands.containsKey(args[0].toLowerCase())) {
 
                 int min = adminCommands.get(args[0].toLowerCase());
@@ -374,27 +375,27 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
                     return null;
 
             }
-            
+
             return YELLOW + Lang.get("questsUnknownAdminCommand");
         }
-            
+
         return "NULL";
     }
-    
+
     public String getQuestsCommandUsage(String cmd) {
-        
+
         return RED + Lang.get("usage") + ":" + YELLOW + "/quests " + Lang.get(Lang.getCommandKey(cmd) + "_HELP");
-        
+
     }
-    
+
     public String getQuestadminCommandUsage(String cmd) {
-        
+
         return RED + Lang.get("usage") + ": " + YELLOW + "/questadmin " + Lang.get(Lang.getCommandKey(cmd) + "_HELP");
-        
+
     }
-    
+
     private void linkOtherPlugins() {
-        
+
         try {
             if (getServer().getPluginManager().getPlugin("Citizens") != null) {
                 citizens = (CitizensPlugin) getServer().getPluginManager().getPlugin("Citizens");
@@ -749,14 +750,14 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
     			return true;
     		}
     	}
-    	
+
         String error = checkCommand(cmd.getName(), args);
-            
-        if(error != null) {    
+
+        if(error != null) {
             cs.sendMessage(error);
             return true;
         }
-        
+
         if (cmd.getName().equalsIgnoreCase("quest")) {
 
             return questCommandHandler(cs, args);
@@ -835,7 +836,11 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
         } else if (args[0].equalsIgnoreCase(Lang.get("COMMAND_QUESTADMIN_STATS"))) {
 
             adminStats(cs, args);
-        
+
+        } else if (args[0].equalsIgnoreCase(Lang.get("COMMAND_QUESTADMIN_REMOVECOMPLETEDQUEST"))) {
+
+            adminRemoveCompletedQuest(cs, args);
+
         } else {
 
             cs.sendMessage(YELLOW + Lang.get("questsUnknownAdminCommand"));
@@ -959,7 +964,7 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
     }
 
     private void adminTakePoints(final CommandSender cs, String[] args) {
-        
+
         if (cs.hasPermission("quests.admin.*") || cs.hasPermission("quests.admin.takepoints")) {
 
             Player target = null;
@@ -1072,7 +1077,7 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
     }
 
     private void adminGive(final CommandSender cs, String[] args) {
-        
+
         if (cs.hasPermission("quests.admin.*") || cs.hasPermission("quests.admin.give")) {
 
             Player target = null;
@@ -1099,21 +1104,21 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
                 if (args.length == 3) {
                     name = args[2].toLowerCase();
                 } else {
-                	
+
                     for (int i = 2; i < args.length; i++) {
-                    	
+
                         int lastIndex = args.length - 1;
-                        
+
                         if (i == lastIndex) {
                         	name = name + args[i].toLowerCase();
                         } else {
                         	name = name + args[i].toLowerCase() + " ";
                         }
-                        
+
                     }
-                    
+
                 }
-                
+
                 questToGive = findQuest(name);
 
                 if (questToGive == null) {
@@ -1121,23 +1126,23 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
                     cs.sendMessage(YELLOW + Lang.get("questNotFound"));
 
                 } else {
-                    
+
                     Quester quester = getQuester(target.getUniqueId());
-                    
+
                     for (Quest q : quester.currentQuests.keySet()) {
-                        
+
                         if(q.getName().equalsIgnoreCase(questToGive.getName())) {
-                            
+
                             String msg = Lang.get("questsPlayerHasQuestAlready");
                             msg = msg.replaceAll("<player>", ITALIC + "" + GREEN + target.getName() + RESET + YELLOW);
                             msg = msg.replaceAll("<quest>", ITALIC + "" + PURPLE + questToGive.getName() + RESET + YELLOW);
                             cs.sendMessage(YELLOW + msg);
-                            
+
                             return;
                         }
-                        
+
                     }
-                    
+
                     quester.hardQuit(questToGive);
 
                     String msg1 = Lang.get("questForceTake");
@@ -1497,7 +1502,7 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
                     }
 
                     quester.hardQuit(found);
-                    
+
                     String msg1 = Lang.get("questForceQuit");
                     msg1 = msg1.replaceAll("<player>", GREEN + target.getName() + GOLD);
                     msg1 = msg1.replaceAll("<quest>", PURPLE + found.name + GOLD);
@@ -1520,13 +1525,13 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
 
         }
     }
-    
+
     private void adminPurge(final CommandSender cs, String[] args) {
 
         if (cs.hasPermission("quests.admin.*") || cs.hasPermission("quests.admin.purge")) {
-        	
+
             UUID id;
-            
+
             try {
 				id = UUIDFetcher.getUUIDOf(args[1]);
 				Quester quester = getQuester(id);
@@ -1538,13 +1543,13 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
 				cs.sendMessage(YELLOW + Lang.get("playerNotFound"));
 				return;
 			}
-            
+
             try {
                 final File dataFolder = new File(this.getDataFolder(), "data/");
                 final File found = new File(dataFolder, id + ".yml");
                 found.delete();
                 addToBlacklist(id);
-                
+
                 String msg = Lang.get("questPurged");
                 msg = msg.replaceAll("<player>", GREEN + Bukkit.getOfflinePlayer(id).getName() + GOLD);
                 cs.sendMessage(GOLD + msg);
@@ -1576,6 +1581,41 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
         }
 
         questsStats(target_online_player, cs);
+    }
+
+    private void adminRemoveCompletedQuest(final CommandSender cs, String[] args) {
+        // Reject usage without permission
+        if (!cs.hasPermission("quests.admin.*") && !cs.hasPermission("quests.admin.removecompletedquest")) {
+            cs.sendMessage(RED + Lang.get("questCmdNoPerms"));
+            return;
+        }
+
+        Player target_online_player = PlayerFinder.findOnlinePlayerByExactCaseInsensitiveNameMatch(args[1]);
+
+        // Reject usage without matching online player
+        if (target_online_player == null) {
+            cs.sendMessage(YELLOW + Lang.get("playerNotFound"));
+            return;
+        }
+
+        Quest quest_to_be_remove = findQuest(MiscUtil.concatArgArray(args, 2, args.length - 1, ' '));
+        if (quest_to_be_remove == null) {
+            cs.sendMessage(RED + Lang.get("questNotFound"));
+            return;
+        }
+
+        UUID target_online_player_uuid = target_online_player.getUniqueId();
+        Quester quester = getQuester(target_online_player_uuid);
+
+        // We do NOT care whather the quester is taking the quest
+
+        String msg = Lang.get("removedQuestFromQuesterCompletedQuests");
+        msg = msg.replaceAll("<player>", GREEN + target_online_player.getName() + GOLD);
+        msg = msg.replaceAll("<quest>", ChatColor.DARK_PURPLE + quest_to_be_remove.name + ChatColor.AQUA);
+        cs.sendMessage(GOLD + msg);
+        cs.sendMessage(PURPLE + " UUID: " + DARKAQUA + target_online_player_uuid);
+
+        quester.removeCompletedQuests(quest_to_be_remove);
     }
 
     private boolean questActionsCommandHandler(final CommandSender cs, String[] args) {
@@ -1620,7 +1660,7 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
                 } else if (args[0].equalsIgnoreCase(Lang.get("COMMAND_EVENTS_EDITOR"))) {
 
                     questsEvents(cs);
-                    
+
                 } else if (args[0].equalsIgnoreCase(Lang.get("COMMAND_INFO"))) {
 
                     questsInfo(cs);
@@ -1816,30 +1856,30 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
         messageTarget.sendMessage(YELLOW + Lang.get("completedQuestsTitle"));
         messageTarget.sendMessage(completed);
     }
-    
+
     private void questsJournal(final Player player) {
 
         Quester quester = getQuester(player.getUniqueId());
-        
+
         if(quester.hasJournal) {
-            
+
             Inventory inv = player.getInventory();
             ItemStack[] arr = inv.getContents();
             for(int i = 0; i < arr.length; i++) {
-                
+
                 if(arr[i] != null) {
                     if(ItemUtil.isJournal(arr[i])) {
                         inv.setItem(i, null);
                         break;
                     }
                 }
-                
+
             }
             player.sendMessage(YELLOW + Lang.get("journalPutAway"));
             quester.hasJournal = false;
-            
+
         } else if(player.getItemInHand() == null || player.getItemInHand().getType().equals(Material.AIR)) {
-            
+
             ItemStack stack = new ItemStack(Material.WRITTEN_BOOK, 1);
             ItemMeta meta = stack.getItemMeta();
             meta.setDisplayName(PINK + Lang.get("journalTitle"));
@@ -1848,14 +1888,14 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
             player.sendMessage(YELLOW + Lang.get("journalTaken"));
             quester.hasJournal = true;
             quester.updateJournal();
-            
+
         } else {
-            
+
             Inventory inv = player.getInventory();
             ItemStack[] arr = inv.getContents();
             boolean given = false;
             for(int i = 0; i < arr.length; i++) {
-                
+
                 if(arr[i] == null) {
                     ItemStack stack = new ItemStack(Material.WRITTEN_BOOK, 1);
                     ItemMeta meta = stack.getItemMeta();
@@ -1866,15 +1906,15 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
                     given = true;
                     break;
                 }
-                
+
             }
-            
+
             if(given) {
                 quester.hasJournal = true;
                 quester.updateJournal();
             }else
                 player.sendMessage(YELLOW + Lang.get("journalNoRoom"));
-            
+
         }
     }
 
@@ -1900,7 +1940,7 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
                     }
 
                     quester.hardQuit(found);
-                    
+
                     String msg = Lang.get("questQuit");
                     msg = msg.replaceAll("<quest>", PURPLE + found.name + YELLOW);
                     player.sendMessage(YELLOW + msg);
@@ -2143,7 +2183,7 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
     }
 
     private boolean questCommandHandler(final CommandSender cs, String[] args) {
-        
+
         if (cs instanceof Player) {
 
             if (((Player) cs).hasPermission("quests.quest")) {
@@ -2421,6 +2461,7 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
             cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_NEXTSTAGE_HELP"));
             cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_SETSTAGE_HELP"));
             cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_PURGE_HELP"));
+            cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_REMOVECOMPLETEDQUEST_HELP"));
             cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_TOGGLEGUI_HELP"));
             cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_RELOAD_HELP"));
         } else{
@@ -2457,13 +2498,16 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
         	if (cs.hasPermission("quests.admin.purge")) {
         		cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_PURGE_HELP"));
         	}
+        	if (cs.hasPermission("quests.admin.removecompletedquest")) {
+        		cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_REMOVECOMPLETEDQUEST_HELP"));
+        	}
         	if (citizens != null && cs.hasPermission("quests.admin.togglegui")) {
         		cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_TOGGLEGUI_HELP"));
         	}
         	if (cs.hasPermission("quests.admin.reload")) {
         		cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_RELOAD_HELP"));
         	}
-        
+
         }
 
     }
@@ -2677,7 +2721,7 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
                     String item = config.getString("quests." + questName + ".gui-display");
                     try {
                     	ItemStack stack = ItemUtil.readItemStack(item);
-                    	
+
                     	if (stack != null) {
                     		quest.guiDisplay = stack;
                     	}
@@ -2917,11 +2961,11 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
                 for (String loot : config.getStringList("quests." + questName + ".rewards.phat-loots")) {
 
                 	if (PhatLootsAPI.getPhatLoot(loot) == null) {
-                			
+
                 		skipQuestProcess("" + loot + " in phat-loots: Reward in Quest " + quest.name + " is not a valid PhatLoot name!");
-                		
+
                 	}
-                		
+
                 }
 
                 quest.phatLootRewards.clear();
@@ -2932,7 +2976,7 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
             }
         }
         }
-        
+
         if (config.contains("quests." + questName + ".rewards.custom-rewards")) {
             populateCustomRewards(config);
         }
@@ -3583,7 +3627,7 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
                                 deliveryMessages.addAll(config.getStringList("quests." + questName + ".stages.ordered." + s2 + ".delivery-messages"));
 
                                 for (String item : itemsToDeliver) {
-                                	
+
                                     ItemStack is = ItemUtil.readItemStack("" + item);
 
                                     if (is != null) {
@@ -3925,7 +3969,7 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
                             List<Integer> mobAmounts = config.getIntegerList("quests." + questName + ".stages.ordered." + s2 + ".mob-tame-amounts");
 
                             for (String mob : mobs) {
-                            	
+
                                 if (mob.equalsIgnoreCase("Wolf") || mob.equalsIgnoreCase("Ocelot") || mob.equalsIgnoreCase("Horse")) {
 
                                     oStage.mobsToTame.put(EntityType.valueOf(mob.toUpperCase()), mobAmounts.get(mobs.indexOf(mob)));
@@ -4353,9 +4397,9 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
         parsed = parsed.replaceAll("<underline>", UNDERLINE.toString());
         parsed = parsed.replaceAll("<strike>", STRIKETHROUGH.toString());
         parsed = parsed.replaceAll("<reset>", RESET.toString());
-        
+
         parsed = parsed.replaceAll("<br>", "\n");
-        
+
         parsed = ChatColor.translateAlternateColorCodes('&', parsed);
 
         return parsed;
@@ -4394,9 +4438,9 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
         parsed = parsed.replaceAll("<underline>", UNDERLINE.toString());
         parsed = parsed.replaceAll("<strike>", STRIKETHROUGH.toString());
         parsed = parsed.replaceAll("<reset>", RESET.toString());
-        
+
         parsed = parsed.replaceAll("<br>", "\n");
-        
+
         parsed = ChatColor.translateAlternateColorCodes('&', parsed);
 
         return parsed;
@@ -4587,7 +4631,7 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
     public static String getTime(long milliseconds) {
 
         String message = "";
-        
+
         long days = milliseconds / 86400000;
         long hours = (milliseconds % 86400000) / 3600000;
         long minutes = ((milliseconds % 86400000) % 3600000) / 60000;
@@ -4813,14 +4857,14 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
     public boolean checkQuester(UUID uuid) {
 
         for (String s : questerBlacklist) {
-        	
+
         	try {
         		UUID.fromString(s);
         		return true;
         	} catch (IllegalArgumentException e) {
                 getLogger().warning(s + " in config.yml is not a valid UUID for quester-blacklist");
         	}
-        	
+
         }
 
         return false;
@@ -5138,7 +5182,7 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
             if (q.npcStart != null && quester.completedQuests.contains(q.name) == false) {
 
                 if (q.npcStart.getId() == npc.getId()) {
-                    
+
                     if(ignoreLockedQuests == false || ignoreLockedQuests == true && q.testRequirements(quester) == true) {
                         return true;
                     }
@@ -5292,26 +5336,26 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
 
                                 final FileConfiguration config = new YamlConfiguration();
                                 final FileConfiguration newConfig = new YamlConfiguration();
-                                
+
                                 config.load(found);
-                                
+
                                 if(config.contains("currentQuest")) {
-                                    
+
                                     LinkedList<String> currentQuests = new LinkedList<String>();
                                     currentQuests.add(config.getString("currentQuest"));
                                     LinkedList<Integer> currentStages = new LinkedList<Integer>();
                                     currentStages.add(config.getInt("currentStage"));
-                                    
+
                                     newConfig.set("currentQuests", currentQuests);
                                     newConfig.set("currentStages", currentStages);
                                     newConfig.set("hasJournal", false);
                                     newConfig.set("lastKnownName", entry.getKey());
-                                    
+
                                     ConfigurationSection dataSec = Quester.getLegacyQuestData(config, config.getString("currentQuest"));
                                     newConfig.set("questData", dataSec);
-                                    
+
                                 }
-                                
+
                                 newConfig.save(copy);
 
                                 found.delete();
@@ -5339,7 +5383,7 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
         }
 
     }
-    
+
     public void addToBlacklist(UUID id) {
     	List<String> blacklist = getConfig().getStringList("quester-blacklist");
     	if (!blacklist.contains(id.toString())) {

--- a/src/main/java/me/blackvein/quests/util/Lang.java
+++ b/src/main/java/me/blackvein/quests/util/Lang.java
@@ -45,9 +45,9 @@ public class Lang {
         return "NULL";
 
     }
-    
+
     public static String getCommandKey(String val) {
-        
+
         for (Entry<String, String> entry : langMap.entrySet()) {
 
             if (entry.getValue().equalsIgnoreCase(val) && entry.getKey().toUpperCase().startsWith("COMMAND_")) {
@@ -57,7 +57,7 @@ public class Lang {
         }
 
         return "NULL";
-        
+
     }
 
     public static void clearPhrases() {
@@ -121,7 +121,7 @@ public class Lang {
 
         langMap.put("COMMAND_INFO", "info");
         langMap.put("COMMAND_INFO_HELP", "info - Display plugin information");
-        
+
         langMap.put("COMMAND_JOURNAL", "journal");
         langMap.put("COMMAND_JOURNAL_HELP", "journal - View/Put away your Quest Journal");
 
@@ -160,9 +160,12 @@ public class Lang {
         langMap.put("COMMAND_QUESTADMIN_SETSTAGE", "setstage");
         langMap.put("COMMAND_QUESTADMIN_SETSTAGE_HELP", "setstage [player] [quest] [stage] - Set the current Stage for a player");
         langMap.put("COMMAND_QUESTADMIN_SETSTAGE_USAGE", "Usage: /questadmin setstage [player] [quest] [stage]");
-        
+
         langMap.put("COMMAND_QUESTADMIN_PURGE", "purge");
         langMap.put("COMMAND_QUESTADMIN_PURGE_HELP", "purge [player] - Clear all Quests data of a player");
+
+        langMap.put("COMMAND_QUESTADMIN_REMOVECOMPLETEDQUEST", "removecompletedquest");
+        langMap.put("COMMAND_QUESTADMIN_REMOVECOMPLETEDQUEST_HELP", "removecompletedquest [player] [quest] - Remove a Quest to a player's completed Quests");
 
         langMap.put("COMMAND_QUESTADMIN_TOGGLEGUI", "togglegui");
         langMap.put("COMMAND_QUESTADMIN_TOGGLEGUI_HELP", "togglegui [npc id] - Toggle GUI Quest Display on an NPC");
@@ -758,7 +761,7 @@ public class Lang {
         langMap.put("questObjectivesTitle", "---(<quest>)---");
         langMap.put("questCompleteTitle", "**QUEST COMPLETE: <quest>**");
         langMap.put("questRewardsTitle", "Rewards:");
-        
+
         langMap.put("journalTitle", "Quest Journal");
 
         langMap.put("questsTitle", "- Quests -");
@@ -923,6 +926,7 @@ public class Lang {
         langMap.put("questForceNextStage", "<player> has advanced to the next Stage in the Quest <quest>.");
         langMap.put("questForcedNextStage", "<player> has advanced you to the next Stage in your Quest <quest>.");
         langMap.put("questPurged", "<player> has been purged and blacklisted.");
+        langMap.put("removedQuestFromQuesterCompletedQuests", "Quest <quest> has been removed from player <player>'s completed Quests.");
         langMap.put("settingAllQuestPoints", "Setting all players' Quest Points...");
         langMap.put("allQuestPointsSet", "All players' Quest Points have been set to <number>!");
 
@@ -947,7 +951,7 @@ public class Lang {
         langMap.put("questsPlayerHasQuestAlready", "<player> is already on the Quest <quest>!");
         langMap.put("questsUnknownAdminCommand", "Unknown Questsadmin command. Type /questsadmin for help.");
         langMap.put("unknownError", "An unknown error occurred. See console output.");
-        
+
         langMap.put("journalTaken", "You take out your Quest Journal.");
         langMap.put("journalPutAway", "You put away your Quest Journal.");
         langMap.put("journalAlreadyHave", "You already have your Quest Journal out.");

--- a/src/main/java/me/blackvein/quests/util/Lang.java
+++ b/src/main/java/me/blackvein/quests/util/Lang.java
@@ -130,6 +130,9 @@ public class Lang {
 
         langMap.put("COMMAND_QUESTADMIN_HELP", "- View Questadmin help");
 
+        langMap.put("COMMAND_QUESTADMIN_STATS", "stats");
+        langMap.put("COMMAND_QUESTADMIN_STATS_HELP", "stats [player] - View Questing statistics of a player");
+
         langMap.put("COMMAND_QUESTADMIN_GIVE", "give");
         langMap.put("COMMAND_QUESTADMIN_GIVE_HELP", "give [player] [quest] - Force a player to take a Quest");
 

--- a/src/main/java/me/blackvein/quests/util/PlayerFinder.java
+++ b/src/main/java/me/blackvein/quests/util/PlayerFinder.java
@@ -1,0 +1,34 @@
+package me.blackvein.quests.util;
+
+import org.bukkit.entity.Player;
+import org.bukkit.Bukkit;
+
+public class PlayerFinder {
+
+    public static Player findOnlinePlayerByPartialCaseInsensitiveNameMatch(String queryString) {
+        Player target_online_player = null;
+
+        for (Player online_player : Bukkit.getOnlinePlayers()) {
+            if (online_player.getName().toLowerCase().contains(queryString.toLowerCase())) {
+                target_online_player = online_player;
+                break;
+            }
+        }
+
+        return target_online_player;
+    }
+
+    public static Player findOnlinePlayerByExactCaseInsensitiveNameMatch(String queryString) {
+        Player target_online_player = null;
+
+        for (Player online_player : Bukkit.getOnlinePlayers()) {
+            if (online_player.getName().equalsIgnoreCase(queryString)) {
+                target_online_player = online_player;
+                break;
+            }
+        }
+
+        return target_online_player;
+    }
+
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -70,6 +70,9 @@ permissions:
     quests.admin.purge:
         description: Clear all Quests data of a player
         default: op
+    quests.admin.removecompletedquest:
+        description: Remove a Quest to a player's completed Quests
+        default: op
     quests.admin.togglegui:
         description: Toggle GUI Quest Display on NPC's
         default: op

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -40,6 +40,9 @@ permissions:
     quests.admin:
         description: Base Questsadmin command
         default: op
+    quests.admin.stats:
+        description: View Questing statistics of a player
+        default: op
     quests.admin.give:
         description: Force a player to take a Quest (Overrides requirements)
         default: op


### PR DESCRIPTION
This is to address #66

# Changes
- New command: `/questadmin stats`
- New command: `/questadmin removecompletedquest`

# Bug
The description shown when typing `/questadmin stats` is using the `/quests stats` one due an existing bug.
This bug only happens when there is a sub-command with same name for prefix `/quests` already.