### PR TITLE
* Return a player with exact name match first when trying to partial match

### DIFF
--- a/src/main/java/me/blackvein/quests/util/PlayerFinder.java
+++ b/src/main/java/me/blackvein/quests/util/PlayerFinder.java
@@ -5,8 +5,18 @@ import org.bukkit.Bukkit;
 
 public class PlayerFinder {
 
+    /**
+     *
+     * @param queryString String that contains part of player name
+     * @return if there is a player with exact name (case insensitive), return it
+     *          else if there is a player with name which contains part of queryString, return it
+     *          else {@code null}
+     */
     public static Player findOnlinePlayerByPartialCaseInsensitiveNameMatch(String queryString) {
-        Player target_online_player = null;
+        Player target_online_player = findOnlinePlayerByExactCaseInsensitiveNameMatch(queryString);
+        if (target_online_player != null) {
+            return target_online_player;
+        }
 
         for (Player online_player : Bukkit.getOnlinePlayers()) {
             if (online_player.getName().toLowerCase().contains(queryString.toLowerCase())) {


### PR DESCRIPTION
This avoids player "fakedude" being return instead of player "dude" when searching for "dude"