### PR TITLE
Quests Compass, Several Bug Fixes

### DIFF
--- a/src/main/java/me/blackvein/quests/CustomObjective.java
+++ b/src/main/java/me/blackvein/quests/CustomObjective.java
@@ -85,11 +85,14 @@ public abstract class CustomObjective implements Listener {
 
         Quester quester = Quests.getInstance().getQuester(player.getUniqueId());
         if (quester != null) {
+            Stage currentStage = quester.getCurrentStage(quest);
+            if (currentStage == null) return null;
 
             int index = -1;
             int tempIndex = 0;
 
-            for (me.blackvein.quests.CustomObjective co : quester.getCurrentStage(quest).customObjectives) {
+
+            for (me.blackvein.quests.CustomObjective co : currentStage.customObjectives) {
 
                 if (co.getName().equals(obj.getName())) {
                     index = tempIndex;
@@ -102,7 +105,7 @@ public abstract class CustomObjective implements Listener {
 
             if (index > -1) {
 
-                return quester.getCurrentStage(quest).customObjectiveData.get(index);
+                return currentStage.customObjectiveData.get(index);
 
             }
 

--- a/src/main/java/me/blackvein/quests/PlayerListener.java
+++ b/src/main/java/me/blackvein/quests/PlayerListener.java
@@ -812,7 +812,8 @@ public class PlayerListener implements Listener, ColorUtil {
 
             for (Quest quest : quester.currentQuests.keySet()) {
 
-                if (quester.getCurrentStage(quest).deathEvent != null) {
+                Stage stage = quester.getCurrentStage(quest);
+                if (stage != null && stage.deathEvent != null) {
                     quester.getCurrentStage(quest).deathEvent.fire(quester, quest);
                 }
 

--- a/src/main/java/me/blackvein/quests/Quest.java
+++ b/src/main/java/me/blackvein/quests/Quest.java
@@ -89,12 +89,7 @@ public class Quest {
         if (stageCompleteMessage != null) {
             q.getPlayer().sendMessage(Quests.parseString(stageCompleteMessage, this));
         }
-
-        Location defaultLocation = q.getPlayer().getBedSpawnLocation();
-        if (defaultLocation == null) {
-            defaultLocation = q.getPlayer().getWorld().getSpawnLocation();
-        }
-        q.getPlayer().setCompassTarget(defaultLocation);
+        resetCompass(q);
 
         if (q.getCurrentStage(this).delay < 0) {
 
@@ -178,18 +173,39 @@ public class Quest {
 
     public void updateCompass(Quester quester, Stage nextStage)
     {
+        Location targetLocation = null;
+        if (nextStage == null) {
+            resetCompass(quester);
+            return;
+        }
         if (nextStage.citizensToInteract != null && nextStage.citizensToInteract.size() > 0)
         {
-            quester.getPlayer().setCompassTarget(plugin.getNPCLocation(nextStage.citizensToInteract.getFirst()));
+            targetLocation = plugin.getNPCLocation(nextStage.citizensToInteract.getFirst());
         }
         else if (nextStage.citizensToKill != null && nextStage.citizensToKill.size() > 0)
         {
-            quester.getPlayer().setCompassTarget(plugin.getNPCLocation(nextStage.citizensToKill.getFirst()));
+            targetLocation = plugin.getNPCLocation(nextStage.citizensToKill.getFirst());
         }
         else if (nextStage.locationsToReach != null && nextStage.locationsToReach.size() > 0)
         {
-            quester.getPlayer().setCompassTarget(nextStage.locationsToReach.getFirst());
+            targetLocation = nextStage.locationsToReach.getFirst();
         }
+        if (targetLocation != null) {
+            quester.getPlayer().setCompassTarget(targetLocation);
+        } else {
+            resetCompass(quester);
+        }
+    }
+
+    protected void resetCompass(Quester q) {
+        Player player = q.getPlayer();
+        if (player == null) return;
+
+        Location defaultLocation = player.getBedSpawnLocation();
+        if (defaultLocation == null) {
+            defaultLocation = player.getWorld().getSpawnLocation();
+        }
+        player.setCompassTarget(defaultLocation);
     }
 
     public String getName() {

--- a/src/main/java/me/blackvein/quests/Quest.java
+++ b/src/main/java/me/blackvein/quests/Quest.java
@@ -173,6 +173,8 @@ public class Quest {
 
     public void updateCompass(Quester quester, Stage nextStage)
     {
+        if (!Quests.getInstance().useCompass) return;
+
         Location targetLocation = null;
         if (nextStage == null) {
             resetCompass(quester);
@@ -198,6 +200,7 @@ public class Quest {
     }
 
     protected void resetCompass(Quester q) {
+        if (!Quests.getInstance().useCompass) return;
         Player player = q.getPlayer();
         if (player == null) return;
 

--- a/src/main/java/me/blackvein/quests/Quest.java
+++ b/src/main/java/me/blackvein/quests/Quest.java
@@ -134,7 +134,6 @@ public class Quest {
     }
 
     public void setStage(Quester quester, int stage) throws InvalidStageException {
-        org.bukkit.Bukkit.getLogger().info("SEt stage: " + stage);
         if (orderedStages.size() - 1 < stage) {
             throw new InvalidStageException(this, stage);
         }

--- a/src/main/java/me/blackvein/quests/Quest.java
+++ b/src/main/java/me/blackvein/quests/Quest.java
@@ -287,16 +287,21 @@ public class Quest {
     @SuppressWarnings("deprecation")
 	public void completeQuest(Quester q) {
 
-        Player player = plugin.getServer().getPlayer(q.id);
+        final Player player = plugin.getServer().getPlayer(q.id);
         q.hardQuit(this);
         q.completedQuests.add(name);
         String none = ChatColor.GRAY + "- (" + Lang.get("none") + ")";
 
-        String ps = Quests.parseString(finished, this);
+        final String ps = Quests.parseString(finished, this);
 
-        for (String msg : ps.split("<br>")) {
-            player.sendMessage(msg);
-        }
+        org.bukkit.Bukkit.getScheduler().runTaskLater(plugin, new Runnable() {
+           @Override
+           public void run() {
+               for (String msg : ps.split("<br>")) {
+                   player.sendMessage(msg);
+               }
+           }
+        }, 40);
 
         if (moneyReward > 0 && Quests.economy != null) {
             Quests.economy.depositPlayer(q.getOfflinePlayer(), moneyReward);

--- a/src/main/java/me/blackvein/quests/Quest.java
+++ b/src/main/java/me/blackvein/quests/Quest.java
@@ -321,7 +321,7 @@ public class Quest {
            @Override
            public void run() {
                for (String msg : ps.split("<br>")) {
-                   player.sendMessage(msg);
+                   player.sendMessage(ChatColor.AQUA + msg);
                }
            }
         }, 40);

--- a/src/main/java/me/blackvein/quests/Quest.java
+++ b/src/main/java/me/blackvein/quests/Quest.java
@@ -90,7 +90,11 @@ public class Quest {
             q.getPlayer().sendMessage(Quests.parseString(stageCompleteMessage, this));
         }
 
-        q.getPlayer().setCompassTarget(q.getPlayer().getWorld().getSpawnLocation());
+        Location defaultLocation = q.getPlayer().getBedSpawnLocation();
+        if (defaultLocation == null) {
+            defaultLocation = q.getPlayer().getWorld().getSpawnLocation();
+        }
+        q.getPlayer().setCompassTarget(defaultLocation);
 
         if (q.getCurrentStage(this).delay < 0) {
 

--- a/src/main/java/me/blackvein/quests/Quest.java
+++ b/src/main/java/me/blackvein/quests/Quest.java
@@ -90,6 +90,8 @@ public class Quest {
             q.getPlayer().sendMessage(Quests.parseString(stageCompleteMessage, this));
         }
 
+        q.getPlayer().setCompassTarget(q.getPlayer().getWorld().getSpawnLocation());
+
         if (q.getCurrentStage(this).delay < 0) {
 
             Player player = q.getPlayer();
@@ -128,7 +130,7 @@ public class Quest {
     }
 
     public void setStage(Quester quester, int stage) throws InvalidStageException {
-
+        org.bukkit.Bukkit.getLogger().info("SEt stage: " + stage);
         if (orderedStages.size() - 1 < stage) {
             throw new InvalidStageException(this, stage);
         }
@@ -147,9 +149,11 @@ public class Quest {
         /*if (quester.getCurrentStage(this).finishEvent != null) {
          quester.getCurrentStage(this).finishEvent.fire(quester);
          }*/
-        if (quester.getCurrentStage(this).startEvent != null) {
-            quester.getCurrentStage(this).startEvent.fire(quester, this);
+        Stage nextStage = quester.getCurrentStage(this);
+        if (nextStage.startEvent != null) {
+            nextStage.startEvent.fire(quester, this);
         }
+        updateCompass(quester, nextStage);
 
         String msg = Lang.get("questObjectivesTitle");
         msg = msg.replaceAll("<quest>", name);
@@ -167,6 +171,22 @@ public class Quest {
         
         quester.updateJournal();
 
+    }
+
+    public void updateCompass(Quester quester, Stage nextStage)
+    {
+        if (nextStage.citizensToInteract != null && nextStage.citizensToInteract.size() > 0)
+        {
+            quester.getPlayer().setCompassTarget(plugin.getNPCLocation(nextStage.citizensToInteract.getFirst()));
+        }
+        else if (nextStage.citizensToKill != null && nextStage.citizensToKill.size() > 0)
+        {
+            quester.getPlayer().setCompassTarget(plugin.getNPCLocation(nextStage.citizensToKill.getFirst()));
+        }
+        else if (nextStage.locationsToReach != null && nextStage.locationsToReach.size() > 0)
+        {
+            quester.getPlayer().setCompassTarget(nextStage.locationsToReach.getFirst());
+        }
     }
 
     public String getName() {

--- a/src/main/java/me/blackvein/quests/QuestFactory.java
+++ b/src/main/java/me/blackvein/quests/QuestFactory.java
@@ -1230,6 +1230,7 @@ public class QuestFactory implements ConversationAbandonedListener, ColorUtil {
 
         if (cc.getSessionData(CK.Q_GUIDISPLAY) != null) {
             guiDisplay = (ItemStack) cc.getSessionData(CK.Q_GUIDISPLAY);
+            guiDisplay = new ItemStack(guiDisplay.getType());
         }
 
         if (cc.getSessionData(CK.REW_MONEY) != null) {

--- a/src/main/java/me/blackvein/quests/Quester.java
+++ b/src/main/java/me/blackvein/quests/Quester.java
@@ -3224,6 +3224,9 @@ if (quest != null) {
             Stage stage = getCurrentStage(quest);
             quest.updateCompass(this, stage);
             exists = true;
+
+            // Meh, let's not.
+            /*
             if (q.equals(quest) == false) {
 
                 hardQuit(quest);
@@ -3236,6 +3239,7 @@ if (quest != null) {
                 }
 
             }
+            */
 
             break;
 

--- a/src/main/java/me/blackvein/quests/Quester.java
+++ b/src/main/java/me/blackvein/quests/Quester.java
@@ -2578,7 +2578,10 @@ public class Quester {
             List<String> questNames = data.getStringList("currentQuests");
             List<Integer> questStages = data.getIntegerList("currentStages");
 
-            for (int i = 0; i < questNames.size(); i++) {
+            // These appear to differ sometimes? That seems bad.
+            int maxSize = Math.min(questNames.size(), questStages.size());
+
+            for (int i = 0; i < maxSize; i++) {
             	if (plugin.getQuest(questNames.get(i)) != null) {
             		currentQuests.put(plugin.getQuest(questNames.get(i)), questStages.get(i));
             	}

--- a/src/main/java/me/blackvein/quests/Quester.java
+++ b/src/main/java/me/blackvein/quests/Quester.java
@@ -2087,15 +2087,17 @@ public class Quester {
             for (Quest quest : currentQuests.keySet()) {
 
                 ConfigurationSection questSec = dataSec.createSection(quest.name);
+                QuestData questData = getQuestData(quest);
+                if (questData == null) continue;
 
-                if (getQuestData(quest).blocksDamaged.isEmpty() == false) {
+                if (questData.blocksDamaged.isEmpty() == false) {
 
                     LinkedList<String> blockNames = new LinkedList<String>();
                     LinkedList<Integer> blockAmounts = new LinkedList<Integer>();
 
-                    for (Material m : getQuestData(quest).blocksDamaged.keySet()) {
+                    for (Material m : questData.blocksDamaged.keySet()) {
                         blockNames.add(m.name());
-                        blockAmounts.add(getQuestData(quest).blocksDamaged.get(m));
+                        blockAmounts.add(questData.blocksDamaged.get(m));
                     }
 
                     questSec.set("blocks-damaged-names", blockNames);
@@ -2103,14 +2105,14 @@ public class Quester {
 
                 }
 
-                if (getQuestData(quest).blocksBroken.isEmpty() == false) {
+                if (questData.blocksBroken.isEmpty() == false) {
 
                     LinkedList<String> blockNames = new LinkedList<String>();
                     LinkedList<Integer> blockAmounts = new LinkedList<Integer>();
 
-                    for (Material m : getQuestData(quest).blocksBroken.keySet()) {
+                    for (Material m : questData.blocksBroken.keySet()) {
                         blockNames.add(m.name());
-                        blockAmounts.add(getQuestData(quest).blocksBroken.get(m));
+                        blockAmounts.add(questData.blocksBroken.get(m));
                     }
 
                     questSec.set("blocks-broken-names", blockNames);
@@ -2118,14 +2120,14 @@ public class Quester {
 
                 }
 
-                if (getQuestData(quest).blocksPlaced.isEmpty() == false) {
+                if (questData.blocksPlaced.isEmpty() == false) {
 
                     LinkedList<String> blockNames = new LinkedList<String>();
                     LinkedList<Integer> blockAmounts = new LinkedList<Integer>();
 
-                    for (Material m : getQuestData(quest).blocksPlaced.keySet()) {
+                    for (Material m : questData.blocksPlaced.keySet()) {
                         blockNames.add(m.name());
-                        blockAmounts.add(getQuestData(quest).blocksPlaced.get(m));
+                        blockAmounts.add(questData.blocksPlaced.get(m));
                     }
 
                     questSec.set("blocks-placed-names", blockNames);
@@ -2133,14 +2135,14 @@ public class Quester {
 
                 }
 
-                if (getQuestData(quest).blocksUsed.isEmpty() == false) {
+                if (questData.blocksUsed.isEmpty() == false) {
 
                     LinkedList<String> blockNames = new LinkedList<String>();
                     LinkedList<Integer> blockAmounts = new LinkedList<Integer>();
 
-                    for (Material m : getQuestData(quest).blocksUsed.keySet()) {
+                    for (Material m : questData.blocksUsed.keySet()) {
                         blockNames.add(m.name());
-                        blockAmounts.add(getQuestData(quest).blocksUsed.get(m));
+                        blockAmounts.add(questData.blocksUsed.get(m));
                     }
 
                     questSec.set("blocks-used-names", blockNames);
@@ -2148,14 +2150,14 @@ public class Quester {
 
                 }
 
-                if (getQuestData(quest).blocksCut.isEmpty() == false) {
+                if (questData.blocksCut.isEmpty() == false) {
 
                     LinkedList<String> blockNames = new LinkedList<String>();
                     LinkedList<Integer> blockAmounts = new LinkedList<Integer>();
 
-                    for (Material m : getQuestData(quest).blocksCut.keySet()) {
+                    for (Material m : questData.blocksCut.keySet()) {
                         blockNames.add(m.name());
-                        blockAmounts.add(getQuestData(quest).blocksCut.get(m));
+                        blockAmounts.add(questData.blocksCut.get(m));
                     }
 
                     questSec.set("blocks-cut-names", blockNames);
@@ -2164,23 +2166,23 @@ public class Quester {
                 }
 
                 if (getCurrentStage(quest).fishToCatch != null) {
-                    questSec.set("fish-caught", getQuestData(quest).getFishCaught());
+                    questSec.set("fish-caught", questData.getFishCaught());
                 }
 
                 if (getCurrentStage(quest).playersToKill != null) {
-                    questSec.set("players-killed", getQuestData(quest).getPlayersKilled());
+                    questSec.set("players-killed", questData.getPlayersKilled());
                 }
 
-                if (getQuestData(quest).itemsEnchanted.isEmpty() == false) {
+                if (questData.itemsEnchanted.isEmpty() == false) {
 
                     LinkedList<String> enchantments = new LinkedList<String>();
                     LinkedList<String> itemNames = new LinkedList<String>();
                     LinkedList<Integer> enchAmounts = new LinkedList<Integer>();
 
-                    for (Entry<Map<Enchantment, Material>, Integer> e : getQuestData(quest).itemsEnchanted.entrySet()) {
+                    for (Entry<Map<Enchantment, Material>, Integer> e : questData.itemsEnchanted.entrySet()) {
 
                         Map<Enchantment, Material> enchMap = (Map<Enchantment, Material>) e.getKey();
-                        enchAmounts.add(getQuestData(quest).itemsEnchanted.get(enchMap));
+                        enchAmounts.add(questData.itemsEnchanted.get(enchMap));
                         for (Entry<Enchantment, Material> e2 : enchMap.entrySet()) {
 
                             enchantments.add(Quester.prettyEnchantmentString((Enchantment) e2.getKey()));
@@ -2196,20 +2198,20 @@ public class Quester {
 
                 }
 
-                if (getQuestData(quest).mobsKilled.isEmpty() == false) {
+                if (questData.mobsKilled.isEmpty() == false) {
 
                     LinkedList<String> mobNames = new LinkedList<String>();
                     LinkedList<Integer> mobAmounts = new LinkedList<Integer>();
                     LinkedList<String> locations = new LinkedList<String>();
                     LinkedList<Integer> radii = new LinkedList<Integer>();
 
-                    for (EntityType e : getQuestData(quest).mobsKilled) {
+                    for (EntityType e : questData.mobsKilled) {
 
                         mobNames.add(Quester.prettyMobString(e));
 
                     }
 
-                    for (int i : getQuestData(quest).mobNumKilled) {
+                    for (int i : questData.mobNumKilled) {
 
                         mobAmounts.add(i);
 
@@ -2218,15 +2220,15 @@ public class Quester {
                     questSec.set("mobs-killed", mobNames);
                     questSec.set("mobs-killed-amounts", mobAmounts);
 
-                    if (getQuestData(quest).locationsToKillWithin.isEmpty() == false) {
+                    if (questData.locationsToKillWithin.isEmpty() == false) {
 
-                        for (Location l : getQuestData(quest).locationsToKillWithin) {
+                        for (Location l : questData.locationsToKillWithin) {
 
                             locations.add(l.getWorld().getName() + " " + l.getX() + " " + l.getY() + " " + l.getZ());
 
                         }
 
-                        for (int i : getQuestData(quest).radiiToKillWithin) {
+                        for (int i : questData.radiiToKillWithin) {
 
                             radii.add(i);
 
@@ -2239,11 +2241,11 @@ public class Quester {
 
                 }
 
-                if (getQuestData(quest).itemsDelivered.isEmpty() == false) {
+                if (questData.itemsDelivered.isEmpty() == false) {
 
                     LinkedList<Integer> deliveryAmounts = new LinkedList<Integer>();
 
-                    for (Entry<ItemStack, Integer> e : getQuestData(quest).itemsDelivered.entrySet()) {
+                    for (Entry<ItemStack, Integer> e : questData.itemsDelivered.entrySet()) {
 
                         deliveryAmounts.add(e.getValue());
 
@@ -2253,15 +2255,15 @@ public class Quester {
 
                 }
 
-                if (getQuestData(quest).citizensInteracted.isEmpty() == false) {
+                if (questData.citizensInteracted.isEmpty() == false) {
 
                     LinkedList<Integer> npcIds = new LinkedList<Integer>();
                     LinkedList<Boolean> hasTalked = new LinkedList<Boolean>();
 
-                    for (Integer n : getQuestData(quest).citizensInteracted.keySet()) {
+                    for (Integer n : questData.citizensInteracted.keySet()) {
 
                         npcIds.add(n);
-                        hasTalked.add(getQuestData(quest).citizensInteracted.get(n));
+                        hasTalked.add(questData.citizensInteracted.get(n));
 
                     }
 
@@ -2270,38 +2272,38 @@ public class Quester {
 
                 }
 
-                if (getQuestData(quest).citizensKilled.isEmpty() == false) {
+                if (questData.citizensKilled.isEmpty() == false) {
 
                     LinkedList<Integer> npcIds = new LinkedList<Integer>();
 
-                    for (Integer n : getQuestData(quest).citizensKilled) {
+                    for (Integer n : questData.citizensKilled) {
 
                         npcIds.add(n);
 
                     }
 
                     questSec.set("citizen-ids-killed", npcIds);
-                    questSec.set("citizen-amounts-killed", getQuestData(quest).citizenNumKilled);
+                    questSec.set("citizen-amounts-killed", questData.citizenNumKilled);
 
                 }
 
-                if (getQuestData(quest).locationsReached.isEmpty() == false) {
+                if (questData.locationsReached.isEmpty() == false) {
 
                     LinkedList<String> locations = new LinkedList<String>();
                     LinkedList<Boolean> has = new LinkedList<Boolean>();
                     LinkedList<Integer> radii = new LinkedList<Integer>();
 
-                    for (Location l : getQuestData(quest).locationsReached) {
+                    for (Location l : questData.locationsReached) {
 
                         locations.add(l.getWorld().getName() + " " + l.getX() + " " + l.getY() + " " + l.getZ());
 
                     }
 
-                    for (boolean b : getQuestData(quest).hasReached) {
+                    for (boolean b : questData.hasReached) {
                         has.add(b);
                     }
 
-                    for (int i : getQuestData(quest).radiiToReachWithin) {
+                    for (int i : questData.radiiToReachWithin) {
                         radii.add(i);
                     }
 
@@ -2311,12 +2313,12 @@ public class Quester {
 
                 }
 
-                if (getQuestData(quest).potionsBrewed.isEmpty() == false) {
+                if (questData.potionsBrewed.isEmpty() == false) {
 
                     LinkedList<String> potionNames = new LinkedList<String>();
                     LinkedList<Integer> potionAmounts = new LinkedList<Integer>();
 
-                    for (Entry<String, Integer> entry : getQuestData(quest).potionsBrewed.entrySet()) {
+                    for (Entry<String, Integer> entry : questData.potionsBrewed.entrySet()) {
 
                         potionNames.add(entry.getKey());
                         potionAmounts.add(entry.getValue());
@@ -2328,15 +2330,15 @@ public class Quester {
 
                 }
 
-                if (getQuestData(quest).mobsTamed.isEmpty() == false) {
+                if (questData.mobsTamed.isEmpty() == false) {
 
                     LinkedList<String> mobNames = new LinkedList<String>();
                     LinkedList<Integer> mobAmounts = new LinkedList<Integer>();
 
-                    for (EntityType e : getQuestData(quest).mobsTamed.keySet()) {
+                    for (EntityType e : questData.mobsTamed.keySet()) {
 
                         mobNames.add(Quester.prettyMobString(e));
-                        mobAmounts.add(getQuestData(quest).mobsTamed.get(e));
+                        mobAmounts.add(questData.mobsTamed.get(e));
 
                     }
 
@@ -2345,15 +2347,15 @@ public class Quester {
 
                 }
 
-                if (getQuestData(quest).sheepSheared.isEmpty() == false) {
+                if (questData.sheepSheared.isEmpty() == false) {
 
                     LinkedList<String> colors = new LinkedList<String>();
                     LinkedList<Integer> shearAmounts = new LinkedList<Integer>();
 
-                    for (DyeColor d : getQuestData(quest).sheepSheared.keySet()) {
+                    for (DyeColor d : questData.sheepSheared.keySet()) {
 
                         colors.add(Quester.prettyColorString(d));
-                        shearAmounts.add(getQuestData(quest).sheepSheared.get(d));
+                        shearAmounts.add(questData.sheepSheared.get(d));
 
                     }
 
@@ -2362,12 +2364,12 @@ public class Quester {
 
                 }
 
-                if (getQuestData(quest).passwordsSaid.isEmpty() == false) {
+                if (questData.passwordsSaid.isEmpty() == false) {
 
                     LinkedList<String> passwords = new LinkedList<String>();
                     LinkedList<Boolean> said = new LinkedList<Boolean>();
 
-                    for (Entry<String, Boolean> entry : getQuestData(quest).passwordsSaid.entrySet()) {
+                    for (Entry<String, Boolean> entry : questData.passwordsSaid.entrySet()) {
 
                         passwords.add(entry.getKey());
                         said.add(entry.getValue());
@@ -2379,12 +2381,12 @@ public class Quester {
 
                 }
 
-                if (getQuestData(quest).customObjectiveCounts.isEmpty() == false) {
+                if (questData.customObjectiveCounts.isEmpty() == false) {
 
                     LinkedList<String> customObj = new LinkedList<String>();
                     LinkedList<Integer> customObjCounts = new LinkedList<Integer>();
 
-                    for (Entry<String, Integer> entry : getQuestData(quest).customObjectiveCounts.entrySet()) {
+                    for (Entry<String, Integer> entry : questData.customObjectiveCounts.entrySet()) {
 
                         customObj.add(entry.getKey());
                         customObjCounts.add(entry.getValue());
@@ -2396,16 +2398,16 @@ public class Quester {
 
                 }
 
-                if (getQuestData(quest).delayTimeLeft > 0) {
-                    questSec.set("stage-delay", getQuestData(quest).delayTimeLeft);
+                if (questData.delayTimeLeft > 0) {
+                    questSec.set("stage-delay", questData.delayTimeLeft);
                 }
 
-                if (getQuestData(quest).eventFired.isEmpty() == false) {
+                if (questData.eventFired.isEmpty() == false) {
 
                     LinkedList<String> triggers = new LinkedList<String>();
-                    for (String trigger : getQuestData(quest).eventFired.keySet()) {
+                    for (String trigger : questData.eventFired.keySet()) {
 
-                        if (getQuestData(quest).eventFired.get(trigger) == true) {
+                        if (questData.eventFired.get(trigger) == true) {
                             triggers.add(trigger);
                         }
 

--- a/src/main/java/me/blackvein/quests/Quester.java
+++ b/src/main/java/me/blackvein/quests/Quester.java
@@ -394,6 +394,7 @@ public class Quester {
             if (stage.startEvent != null) {
                 stage.startEvent.fire(this, q);
             }
+            q.updateCompass(this, stage);
 
             saveData();
 
@@ -3219,9 +3220,9 @@ if (quest != null) {
     boolean exists = false;
 
     for (Quest q : plugin.quests) {
-
         if (q.name.equalsIgnoreCase(quest.name)) {
-
+            Stage stage = getCurrentStage(quest);
+            quest.updateCompass(this, stage);
             exists = true;
             if (q.equals(quest) == false) {
 

--- a/src/main/java/me/blackvein/quests/Quests.java
+++ b/src/main/java/me/blackvein/quests/Quests.java
@@ -4979,6 +4979,12 @@ try{
 
     }
 
+    public Location getNPCLocation(int id) {
+
+        return citizens.getNPCRegistry().getById(id).getStoredLocation();
+
+    }
+
     public String getNPCName(int id) {
 
         return citizens.getNPCRegistry().getById(id).getName();

--- a/src/main/java/me/blackvein/quests/Quests.java
+++ b/src/main/java/me/blackvein/quests/Quests.java
@@ -1600,26 +1600,35 @@ try{
                 cs.sendMessage(YELLOW + Lang.get("playerNotFound"));
                 return;
             }
+            UUID id = quester.id;
+            questers.remove(id);
 
             try {
                 quester.hardClear();
                 quester.saveData();
                 quester.updateJournal();
                 final File dataFolder = new File(this.getDataFolder(), "data/");
-                final File found = new File(dataFolder, quester.id + ".yml");
+                final File found = new File(dataFolder, id + ".yml");
                 found.delete();
 
                 String msg = Lang.get("questReset");
-                if (Bukkit.getOfflinePlayer(quester.id).getName() != null) {
-                    msg = msg.replaceAll("<player>", GREEN + Bukkit.getOfflinePlayer(quester.id).getName() + GOLD);
+                if (Bukkit.getOfflinePlayer(id).getName() != null) {
+                    msg = msg.replaceAll("<player>", GREEN + Bukkit.getOfflinePlayer(id).getName() + GOLD);
                 } else {
                     msg = msg.replaceAll("<player>", GREEN + args[1] + GOLD);
                 }
                 cs.sendMessage(GOLD + msg);
-                cs.sendMessage(PURPLE + " UUID: " + DARKAQUA + quester.id);
+                cs.sendMessage(PURPLE + " UUID: " + DARKAQUA + id);
+
+
             } catch (Exception e) {
-                getLogger().info("Data file does not exist for " + quester.id.toString());
+                getLogger().info("Data file does not exist for " + id.toString());
             }
+
+            quester = new Quester(this);
+            quester.id = id;
+            quester.saveData();
+            questers.put(id, quester);
 
         } else {
 

--- a/src/main/java/me/blackvein/quests/Quests.java
+++ b/src/main/java/me/blackvein/quests/Quests.java
@@ -98,6 +98,7 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
     public static Heroes heroes = null;
     public static PhatLoots phatLoots = null;
     public static boolean npcEffects = true;
+    public static boolean useCompass = true;
     public static boolean ignoreLockedQuests = false;
     public static boolean genFilesOnJoin = true;
     public static int acceptTimeout = 20;
@@ -533,6 +534,7 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
         allowCommandsForNpcQuests = config.getBoolean("allow-command-quests-with-npcs", false);
         showQuestReqs = config.getBoolean("show-requirements", true);
         allowQuitting = config.getBoolean("allow-quitting", true);
+        useCompass = config.getBoolean("use-compass", true);
         genFilesOnJoin = config.getBoolean("generate-files-on-join", true);
         npcEffects = config.getBoolean("show-npc-effects", true);
         effect = config.getString("npc-effect", "note");

--- a/src/main/java/me/blackvein/quests/Quests.java
+++ b/src/main/java/me/blackvein/quests/Quests.java
@@ -336,6 +336,7 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
         adminCommands.put(Lang.get("COMMAND_QUESTADMIN_NEXTSTAGE"), 3); // nextstage [player] [quest]
         adminCommands.put(Lang.get("COMMAND_QUESTADMIN_SETSTAGE"), 4); // setstage [player] [quest] [stage]
         adminCommands.put(Lang.get("COMMAND_QUESTADMIN_PURGE"), 2); // purge [player]
+        adminCommands.put(Lang.get("COMMAND_QUESTADMIN_RESET"), 2); // purge [player]
         adminCommands.put(Lang.get("COMMAND_QUESTADMIN_TOGGLEGUI"), 2); // togglegui [npc id]
         adminCommands.put(Lang.get("COMMAND_QUESTADMIN_RELOAD"), 1); // reload
 
@@ -846,6 +847,10 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener,
         } else if (args[0].equalsIgnoreCase(Lang.get("COMMAND_QUESTADMIN_PURGE"))) {
 
             adminPurge(cs, args);
+
+        } else if (args[0].equalsIgnoreCase(Lang.get("COMMAND_QUESTADMIN_RESET"))) {
+
+            adminReset(cs, args);
 
         } else if (args[0].equalsIgnoreCase(Lang.get("COMMAND_QUESTADMIN_STATS"))) {
 
@@ -1574,6 +1579,44 @@ try{
                 cs.sendMessage(PURPLE + " UUID: " + DARKAQUA + quester.id);
             } catch (Exception e) {
             	getLogger().info("Data file does not exist for " + quester.id.toString());
+            }
+
+        } else {
+
+            cs.sendMessage(RED + Lang.get("questCmdNoPerms"));
+
+        }
+    }
+
+    private void adminReset(final CommandSender cs, String[] args) {
+
+        if (cs.hasPermission("quests.admin.*") || cs.hasPermission("quests.admin.reset")) {
+
+            Quester quester = getQuester(args[1]);
+
+            if (quester == null) {
+                cs.sendMessage(YELLOW + Lang.get("playerNotFound"));
+                return;
+            }
+
+            try {
+                quester.hardClear();
+                quester.saveData();
+                quester.updateJournal();
+                final File dataFolder = new File(this.getDataFolder(), "data/");
+                final File found = new File(dataFolder, quester.id + ".yml");
+                found.delete();
+
+                String msg = Lang.get("questReset");
+                if (Bukkit.getOfflinePlayer(quester.id).getName() != null) {
+                    msg = msg.replaceAll("<player>", GREEN + Bukkit.getOfflinePlayer(quester.id).getName() + GOLD);
+                } else {
+                    msg = msg.replaceAll("<player>", GREEN + args[1] + GOLD);
+                }
+                cs.sendMessage(GOLD + msg);
+                cs.sendMessage(PURPLE + " UUID: " + DARKAQUA + quester.id);
+            } catch (Exception e) {
+                getLogger().info("Data file does not exist for " + quester.id.toString());
             }
 
         } else {
@@ -2492,6 +2535,7 @@ try{
             cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_NEXTSTAGE_HELP"));
             cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_SETSTAGE_HELP"));
             cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_PURGE_HELP"));
+            cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_RESET_HELP"));
             cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_REMOVE_HELP"));
             cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_TOGGLEGUI_HELP"));
             cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_RELOAD_HELP"));
@@ -2529,6 +2573,9 @@ try{
         	if (cs.hasPermission("quests.admin.purge")) {
         		cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_PURGE_HELP"));
         	}
+            if (cs.hasPermission("quests.admin.reset")) {
+                cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_RESET_HELP"));
+            }
         	if (cs.hasPermission("quests.admin.remove")) {
         		cs.sendMessage(DARKRED + "/questadmin " + RED + Lang.get("COMMAND_QUESTADMIN_REMOVE_HELP"));
         	}

--- a/src/main/java/me/blackvein/quests/Quests.java
+++ b/src/main/java/me/blackvein/quests/Quests.java
@@ -2560,7 +2560,7 @@ try{
 
             if (numOrder > 1) {
                 if (quests.size() >= (numOrder + 7)) {
-                    subQuests = quests.subList((numOrder), (numOrder + 8));
+                    subQuests = quests.subList((numOrder), (numOrder + 7));
                 } else {
                     subQuests = quests.subList((numOrder), quests.size());
                 }

--- a/src/main/java/me/blackvein/quests/prompts/ItemStackPrompt.java
+++ b/src/main/java/me/blackvein/quests/prompts/ItemStackPrompt.java
@@ -1,5 +1,6 @@
 package me.blackvein.quests.prompts;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -177,7 +178,7 @@ public class ItemStackPrompt extends FixedSetPrompt implements ColorUtil {
                 short data = -1;
                 Map<Enchantment, Integer> enchs = null;
                 String display = null;
-                LinkedList<String> lore = null;
+                List<String> lore = null;
 
                 if (cc.getSessionData("tempData") != null) {
                     data = (Short) cc.getSessionData("tempData");
@@ -187,9 +188,15 @@ public class ItemStackPrompt extends FixedSetPrompt implements ColorUtil {
                 }
                 if (cc.getSessionData("tempDisplay") != null) {
                     display = ChatColor.translateAlternateColorCodes('&', (String) cc.getSessionData("tempDisplay"));
+                    org.bukkit.Bukkit.getLogger().info("LOADED: " + display);
                 }
                 if (cc.getSessionData("tempLore") != null) {
-                    lore = (LinkedList<String>) cc.getSessionData("tempLore");
+                    lore = new ArrayList<String>();
+                    LinkedList<String> loadedLore = (LinkedList<String>) cc.getSessionData("tempLore");
+                    for (String line : loadedLore)
+                    {
+                        lore.add(ChatColor.translateAlternateColorCodes('&', line));
+                    }
                 }
 
                 ItemStack stack = new ItemStack(Material.matchMaterial(name), amount);

--- a/src/main/java/me/blackvein/quests/prompts/ItemStackPrompt.java
+++ b/src/main/java/me/blackvein/quests/prompts/ItemStackPrompt.java
@@ -188,7 +188,6 @@ public class ItemStackPrompt extends FixedSetPrompt implements ColorUtil {
                 }
                 if (cc.getSessionData("tempDisplay") != null) {
                     display = ChatColor.translateAlternateColorCodes('&', (String) cc.getSessionData("tempDisplay"));
-                    org.bukkit.Bukkit.getLogger().info("LOADED: " + display);
                 }
                 if (cc.getSessionData("tempLore") != null) {
                     lore = new ArrayList<String>();

--- a/src/main/java/me/blackvein/quests/prompts/ItemStackPrompt.java
+++ b/src/main/java/me/blackvein/quests/prompts/ItemStackPrompt.java
@@ -95,7 +95,8 @@ public class ItemStackPrompt extends FixedSetPrompt implements ColorUtil {
 
                     ItemMeta meta = is.getItemMeta();
                     if (meta.hasDisplayName()) {
-                        cc.setSessionData("tempDisplay", ChatColor.stripColor(meta.getDisplayName()));
+                        String display = meta.getDisplayName().replace(ChatColor.COLOR_CHAR, '&');
+                        cc.setSessionData("tempDisplay", display);
                     }
                     if (meta.hasLore()) {
                         LinkedList<String> lore = new LinkedList<String>();
@@ -185,7 +186,7 @@ public class ItemStackPrompt extends FixedSetPrompt implements ColorUtil {
                     enchs = (Map<Enchantment, Integer>) cc.getSessionData("tempEnchantments");
                 }
                 if (cc.getSessionData("tempDisplay") != null) {
-                    display = (String) cc.getSessionData("tempDisplay");
+                    display = ChatColor.translateAlternateColorCodes('&', (String) cc.getSessionData("tempDisplay"));
                 }
                 if (cc.getSessionData("tempLore") != null) {
                     lore = (LinkedList<String>) cc.getSessionData("tempLore");

--- a/src/main/java/me/blackvein/quests/util/ItemUtil.java
+++ b/src/main/java/me/blackvein/quests/util/ItemUtil.java
@@ -104,9 +104,9 @@ public class ItemUtil implements ColorUtil {
                 Enchantment e = Quests.getEnchantment(enchs[0]);
                 meta.addEnchant(e, Integer.parseInt(enchs[1]), true);
             } else if (arg.startsWith("displayname-")) {
-                meta.setDisplayName(arg.substring(12));
+                meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', arg.substring(12)));
             } else if (arg.startsWith("lore-")) {
-                lore.add(arg.substring(5));
+                lore.add(ChatColor.translateAlternateColorCodes('&', arg.substring(5)));
             } else {
             	return null;
             }

--- a/src/main/java/me/blackvein/quests/util/Lang.java
+++ b/src/main/java/me/blackvein/quests/util/Lang.java
@@ -162,7 +162,10 @@ public class Lang {
         langMap.put("COMMAND_QUESTADMIN_SETSTAGE_USAGE", "Usage: /questadmin setstage [player] [quest] [stage]");
 
         langMap.put("COMMAND_QUESTADMIN_PURGE", "purge");
-        langMap.put("COMMAND_QUESTADMIN_PURGE_HELP", "purge [player] - Clear all Quests data of a player");
+        langMap.put("COMMAND_QUESTADMIN_PURGE_HELP", "purge [player] - Clear all Quests data of a player AND BLACKLISTS THEM");
+
+        langMap.put("COMMAND_QUESTADMIN_RESET", "reset");
+        langMap.put("COMMAND_QUESTADMIN_RESET_HELP", "reset [player] - Clear all Quests data of a player");
 
         langMap.put("COMMAND_QUESTADMIN_REMOVE", "remove");
         langMap.put("COMMAND_QUESTADMIN_REMOVE_HELP", "remove [player] [quest] - Remove a completed Quest from a player");
@@ -927,6 +930,7 @@ public class Lang {
         langMap.put("questForceNextStage", "<player> has advanced to the next Stage in the Quest <quest>.");
         langMap.put("questForcedNextStage", "<player> has advanced you to the next Stage in your Quest <quest>.");
         langMap.put("questPurged", "<player> has been purged and blacklisted.");
+        langMap.put("questReset", "<player> has been reset.");
         langMap.put("questRemoved", "Quest <quest> has been removed from player <player>'s completed Quests.");
         langMap.put("settingAllQuestPoints", "Setting all players' Quest Points...");
         langMap.put("allQuestPointsSet", "All players' Quest Points have been set to <number>!");

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,6 +3,7 @@ allow-command-questing: true
 allow-command-quests-with-npcs: false
 show-requirements: true
 allow-quitting: true
+use-compass: true
 ignore-locked-quests: false
 debug-mode: false
 generate-files-on-join: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -68,6 +68,9 @@ permissions:
         description: Immediately force Stage completion for a player
         default: op
     quests.admin.purge:
+        description: Clear all Quests data of a player AND BLACKLISTS THEM
+        default: op
+    quests.admin.reset:
         description: Clear all Quests data of a player
         default: op
     quests.admin.remove:


### PR DESCRIPTION
New feature: quests with target NPCs or locations will use the player's compass to guide them there. This can be disabled via a config setting.

New command: /questsadmin reset, to reset a player without blacklisting them. Useful for testing/debugging.

Change: Quest finish text is highlighted and delays so that it appears a couple of seconds after rewards and other info. This is to make sure instructions can be given and seen by the player when completing a quest.

Controversial Change: I disabled the check for quests having changed on reload. I'm not sure if it's specific to my set up, but this seems to fire every single time- meaning I can't really use /questsadmin reload, or it will kill all online players out of any active quests. I'm up for discussing this point.

There are also several random bug fixes here and there, please check commits.

I'd also be up for splitting this up into separate commits if need be- I've sat on these changes for a while but wanted to share.