### PR TITLE
Better compass behavior, safety protection when loading bad data

### DIFF
--- a/src/main/java/me/blackvein/quests/PlayerListener.java
+++ b/src/main/java/me/blackvein/quests/PlayerListener.java
@@ -7,6 +7,7 @@ import me.blackvein.quests.util.ItemUtil;
 import me.blackvein.quests.util.Lang;
 import net.citizensnpcs.api.CitizensAPI;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -35,6 +36,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.event.player.PlayerFishEvent.State;
@@ -43,6 +45,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.event.player.PlayerShearEntityEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.projectiles.ProjectileSource;
@@ -858,6 +861,29 @@ public class PlayerListener implements Listener, ColorUtil {
 
         }
 
+    }
+
+    @EventHandler
+    public void onPlayerChangeWorld(PlayerChangedWorldEvent event) {
+        Player player = event.getPlayer();
+        if (plugin.checkQuester(player.getUniqueId()) == false) {
+            Quester quester = plugin.getQuester(player.getUniqueId());
+            quester.findCompassTarget();
+        }
+    }
+
+    @EventHandler
+    public void onPlayerRespawn(PlayerRespawnEvent event) {
+        Player player = event.getPlayer();
+        if (plugin.checkQuester(player.getUniqueId()) == false) {
+            final Quester quester = plugin.getQuester(player.getUniqueId());
+            Bukkit.getScheduler().runTaskLater(plugin, new Runnable() {
+               @Override
+                public void run() {
+                   quester.findCompassTarget();
+               }
+            }, 10);
+        }
     }
 
     @EventHandler

--- a/src/main/java/me/blackvein/quests/PlayerListener.java
+++ b/src/main/java/me/blackvein/quests/PlayerListener.java
@@ -875,6 +875,10 @@ public class PlayerListener implements Listener, ColorUtil {
 
             plugin.questers.put(evt.getPlayer().getUniqueId(), quester);
 
+            if (Quests.getInstance().useCompass) {
+                quester.resetCompass();
+            }
+
             for (String s : quester.completedQuests) {
 
                 Quest q = plugin.getQuest(s);

--- a/src/main/java/me/blackvein/quests/Quest.java
+++ b/src/main/java/me/blackvein/quests/Quest.java
@@ -195,6 +195,7 @@ public class Quest {
             targetLocation = nextStage.locationsToReach.getFirst();
         }
         if (targetLocation != null) {
+//            org.bukkit.Bukkit.getLogger().info(" setting compass target for " + quester.getPlayer().getName() + " to " + targetLocation);
             quester.getPlayer().setCompassTarget(targetLocation);
         }
         

--- a/src/main/java/me/blackvein/quests/Quest.java
+++ b/src/main/java/me/blackvein/quests/Quest.java
@@ -564,7 +564,7 @@ public class Quest {
         q.saveData();
         player.updateInventory();
         q.updateJournal();
-
+        q.findCompassTarget();
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/me/blackvein/quests/Quest.java
+++ b/src/main/java/me/blackvein/quests/Quest.java
@@ -89,7 +89,10 @@ public class Quest {
         if (stageCompleteMessage != null) {
             q.getPlayer().sendMessage(Quests.parseString(stageCompleteMessage, this));
         }
-        resetCompass(q);
+        if (Quests.getInstance().useCompass) {
+            q.resetCompass();
+            q.findCompassTarget();
+        }
 
         if (q.getCurrentStage(this).delay < 0) {
 
@@ -171,14 +174,13 @@ public class Quest {
 
     }
 
-    public void updateCompass(Quester quester, Stage nextStage)
+    public boolean updateCompass(Quester quester, Stage nextStage)
     {
-        if (!Quests.getInstance().useCompass) return;
+        if (!Quests.getInstance().useCompass) return false;
 
         Location targetLocation = null;
         if (nextStage == null) {
-            resetCompass(quester);
-            return;
+            return false;
         }
         if (nextStage.citizensToInteract != null && nextStage.citizensToInteract.size() > 0)
         {
@@ -194,21 +196,9 @@ public class Quest {
         }
         if (targetLocation != null) {
             quester.getPlayer().setCompassTarget(targetLocation);
-        } else {
-            resetCompass(quester);
         }
-    }
-
-    protected void resetCompass(Quester q) {
-        if (!Quests.getInstance().useCompass) return;
-        Player player = q.getPlayer();
-        if (player == null) return;
-
-        Location defaultLocation = player.getBedSpawnLocation();
-        if (defaultLocation == null) {
-            defaultLocation = player.getWorld().getSpawnLocation();
-        }
-        player.setCompassTarget(defaultLocation);
+        
+        return targetLocation != null;
     }
 
     public String getName() {

--- a/src/main/java/me/blackvein/quests/Quest.java
+++ b/src/main/java/me/blackvein/quests/Quest.java
@@ -194,8 +194,8 @@ public class Quest {
         {
             targetLocation = nextStage.locationsToReach.getFirst();
         }
-        if (targetLocation != null) {
-//            org.bukkit.Bukkit.getLogger().info(" setting compass target for " + quester.getPlayer().getName() + " to " + targetLocation);
+        if (targetLocation != null && targetLocation.getWorld().equals(quester.getPlayer().getWorld())) {
+            // plugin.getLogger().info("Setting compass target for " + quester.getPlayer().getName() + " to " + targetLocation);
             quester.getPlayer().setCompassTarget(targetLocation);
         }
         

--- a/src/main/java/me/blackvein/quests/Quester.java
+++ b/src/main/java/me/blackvein/quests/Quester.java
@@ -2590,7 +2590,7 @@ public class Quester {
 
             ConfigurationSection dataSec = data.getConfigurationSection("questData");
 
-            if (dataSec.getKeys(false).isEmpty()) {
+            if (dataSec == null || dataSec.getKeys(false).isEmpty()) {
             	return false;
             }
 
@@ -2610,10 +2610,12 @@ public class Quester {
                 if (stage == null) {
                     quest.completeQuest(this);
                     plugin.getLogger().log(Level.SEVERE, "[Quests] Invalid stage number for player: \"" + id + "\" on Quest \"" + quest.name + "\". Quest ended.");
-                    return true;
+                    continue;
                 }
 
                 addEmpties(quest);
+
+                if (questSec == null) continue;
 
                 if (questSec.contains("blocks-damaged-names")) {
 

--- a/src/main/java/me/blackvein/quests/Quester.java
+++ b/src/main/java/me/blackvein/quests/Quester.java
@@ -3466,5 +3466,27 @@ if (quest != null) {
         }
 
     }
+    
+    public void resetCompass() {
+        if (!Quests.getInstance().useCompass) return;
+        Player player = getPlayer();
+        if (player == null) return;
 
+        Location defaultLocation = player.getBedSpawnLocation();
+        if (defaultLocation == null) {
+            defaultLocation = player.getWorld().getSpawnLocation();
+        }
+        player.setCompassTarget(defaultLocation);
+    }
+    
+    public void findCompassTarget() {
+        if (!Quests.getInstance().useCompass) return;
+        Player player = getPlayer();
+        if (player == null) return;
+        
+        for (Quest quest : currentQuests.keySet()) {
+            Stage stage = getCurrentStage(quest);
+            if (stage != null && quest.updateCompass(this, stage)) break;
+        }
+    }
 }

--- a/src/main/java/me/blackvein/quests/Quests.java
+++ b/src/main/java/me/blackvein/quests/Quests.java
@@ -2747,6 +2747,8 @@ try{
                 quester.saveData();
             }
             qs.put(p.getUniqueId(), quester);
+            // Kind of hacky to put this here, works around issues with the compass on fast join
+            quester.findCompassTarget();
 
         }
 

--- a/src/main/java/me/blackvein/quests/Quests.java
+++ b/src/main/java/me/blackvein/quests/Quests.java
@@ -2495,12 +2495,13 @@ try{
 
     private void showObjectives(final Player player) {
 
-        if (getQuester(player.getUniqueId()).currentQuests.isEmpty() == false) {
-
-            for (Quest q : getQuester(player.getUniqueId()).currentQuests.keySet()) {
+        Quester quester = getQuester(player.getUniqueId());
+        if (quester.currentQuests.isEmpty() == false) {
+            for (Quest q : quester.currentQuests.keySet()) {
+                Stage stage = quester.getCurrentStage(q);
+                q.updateCompass(quester, stage);
 
             	try {
-            	
                 if (getQuester(player.getUniqueId()).getQuestData(q).delayStartTime == 0) {
 
                     String msg = Lang.get("questObjectivesTitle");


### PR DESCRIPTION
This fixes compass behavior when multiple quests are active, and also fixes a specific issue I ran into that I believe was caused by a quester save file failing to write due to some server issues we had, causing it to fail to load on restart.