### PR TITLE
Stop error spam on 1.9 - Actual 1.9 update for particles.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,13 @@
         </dependency>
         <dependency>
             <groupId>org.bukkit</groupId>
+            <artifactId>spigot192</artifactId>
+            <version>1.9.2-R0.1-SNAPSHOT</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/lib/craftbukkit-1.9.2.jar</systemPath>
+        </dependency>
+        <dependency>
+            <groupId>org.bukkit</groupId>
             <artifactId>bukkit1710</artifactId>
             <version>1.7.10-R0.1</version>
             <scope>system</scope>

--- a/src/main/java/me/blackvein/particles/Eff_1_9_R1.java
+++ b/src/main/java/me/blackvein/particles/Eff_1_9_R1.java
@@ -1,11 +1,11 @@
 package me.blackvein.particles;
 
 import me.blackvein.quests.util.ReflectionUtil;
-import net.minecraft.server.v1_8_R3.EnumParticle;
-import net.minecraft.server.v1_8_R3.PacketPlayOutWorldParticles;
+import net.minecraft.server.v1_9_R1.EnumParticle;
+import net.minecraft.server.v1_9_R1.PacketPlayOutWorldParticles;
 
 import org.bukkit.Location;
-import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_9_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
 public enum Eff_1_9_R1 {


### PR DESCRIPTION
This fixes the error spam on 1.9 and makes the particles work again.