### PR TITLE
Fix cooldown of completedRedoableQuests being set to first entry for all quests.

### DIFF
--- a/src/main/java/me/blackvein/quests/Quester.java
+++ b/src/main/java/me/blackvein/quests/Quester.java
@@ -1899,18 +1899,21 @@ public class Quester {
 			return false;
 		}
 		hardClear();
-		if (data.contains("completedRedoableQuests")) {
-			for (String s : data.getStringList("completedRedoableQuests")) {
-				for (Object o : data.getList("completedQuestTimes")) {
-					for (Quest q : plugin.quests) {
-						if (q.name.equalsIgnoreCase(s)) {
-							completedTimes.put(q.name, (Long) o);
-							break;
-						}
-					}
-				}
-			}
-		}
+        if (data.contains("completedRedoableQuests") && data.contains("completedQuestTimes")) {
+            List<String> redoableQuestNames = data.getStringList("completedRedoableQuests");
+            List<Object> redoableQuestTimes = (List<Object>) data.getList("completedQuestTimes");
+
+            if (redoableQuestNames.size() != redoableQuestTimes.size()) {
+                plugin.getLogger().log(Level.WARNING, "completedRedoableQuests has " + redoableQuestNames.size() + " Entries but completedQuestTimes has " + redoableQuestTimes.size() + " Entries for player " + id.toString() + ". This will cause errors, trying to prevent complete data loss now.");
+            }
+
+            for (int i = 0; i < redoableQuestNames.size(); i++) {
+                if (i < redoableQuestTimes.size())
+                    completedTimes.put(redoableQuestNames.get(i), (Long) redoableQuestTimes.get(i));
+                else
+                    completedTimes.put(redoableQuestNames.get(i), System.currentTimeMillis()); // This will cause the cooldown to be reset but at least, the rest of the data does not get lost
+            }
+        }
 		if (data.contains("amountsCompletedQuests")) {
 			List<String> list1 = data.getStringList("amountsCompletedQuests");
 			List<Integer> list2 = data.getIntegerList("amountsCompleted");


### PR DESCRIPTION
I'm not a hundred percent sure, when this happens, but under some circumstances (or always?), every quest that is inserted into completedRedoableQuests gets the same cooldown (the first entry of completedQuestTimes).

This commit changes the current behaviour, it fetches both lists (completedRedoableQuests/redoableQuestNames and completedQuestTimes/redoableQuestTimes) and matches them together (the first entry of redoableQuestNames gets matched with the first entry of redoableQuestTimes and so on).

If there is not the same amount of entries in both lists, a warning gets printed to the console informing about the possible cooldown-loss.

If there are more entries in redoableQuestNames than in redoableQuestTimes, the missing cooldown a reset with the current timestamp, if there a more entries in redoableQuestTimes than in redoableQuestNames the unnecessary timestamps get deleted and the next save (as they are not in the hashmap).

The warning and the fail-safe-behaviour should never occur but it's better to be safe than sorry.