### PR TITLE
Store Quester instance before loading data

### DIFF
--- a/src/main/java/me/blackvein/quests/Quests.java
+++ b/src/main/java/me/blackvein/quests/Quests.java
@@ -2028,8 +2028,9 @@ public class Quests extends JavaPlugin implements ConversationAbandonedListener 
 					return quester;
 				}
 			}
-			if (quester.loadData() == true) {
-				questers.put(id, quester);
+			questers.put(id, quester);
+			if (!quester.loadData()) {
+				questers.remove(id);
 			}
 		}
 		return quester;


### PR DESCRIPTION
This avoids a scenario in which the plugin attempts to load Quester instances recursively. For instance:

- A player has an invalid stage index for a given quest
- The quest has a reward which invokes the `questadmin` command (for quest chaining, for example)
- On join, the plugin attempts to load the quest data and sees the invalid stage, and attempts to complete the quest (executing the reward command in the process)
- The `questadmin` command invokes `Quests#getQuester`, which attempts to load the data since no instance has been stored yet, creating a non-terminating recursive call chain

This PR simply stores the Quester instance before `Quester#loadData` is called, completely avoiding this scenario.